### PR TITLE
Update production postgres sku from v4 to v5

### DIFF
--- a/terraform/application/config/production.tfvars.json
+++ b/terraform/application/config/production.tfvars.json
@@ -4,7 +4,7 @@
     "environment": "production",
     "enable_postgres_backup_storage" : true,
     "enable_postgres_high_availability": true,
-    "postgres_flexible_server_sku": "GP_Standard_D2ds_v4",
+    "postgres_flexible_server_sku": "GP_Standard_D2ds_v5",
     "storage_container_delete_retention_days": 7,
     "azure_maintenance_window": {
         "day_of_week": 0,


### PR DESCRIPTION
# Description

Update the production postgres sku to v5
It's the same cost as v4 for better performance.
There will be a 10-20 minute downtime for the database server when this is applied

# How Has This Been Tested?

make production terraform-plan
Other services have already upgraded to v5 without issue

<img width="633" height="193" alt="image" src="https://github.com/user-attachments/assets/d8651b11-c1fb-4687-a99c-0c13babc9f77" />

