### PR TITLE
Add similar school in attendance

### DIFF
--- a/SAPSec.Core/Features/Attendance/UseCases/GetAttendanceMeasures.cs
+++ b/SAPSec.Core/Features/Attendance/UseCases/GetAttendanceMeasures.cs
@@ -1,3 +1,4 @@
+using SAPSec.Core.Features.SimilarSchools;
 using SAPSec.Core.Interfaces.Repositories;
 using System.Globalization;
 
@@ -5,7 +6,8 @@ namespace SAPSec.Core.Features.Attendance.UseCases;
 
 public class GetAttendanceMeasures(
     IAbsenceRepository repository,
-    IEstablishmentRepository establishmentRepository)
+    IEstablishmentRepository establishmentRepository,
+    ISimilarSchoolsSecondaryRepository similarSchoolsRepository)
 {
     public async Task<GetAttendanceMeasuresResponse> Execute(GetAttendanceMeasuresRequest request)
     {
@@ -16,6 +18,14 @@ public class GetAttendanceMeasures(
         }
 
         var data = await repository.GetByUrnAsync(request.Urn);
+        var similarSchoolUrns = (await similarSchoolsRepository.GetSimilarSchoolsGroupAsync(request.Urn))
+            .Select(x => x.NeighbourURN)
+            .Where(x => !string.IsNullOrWhiteSpace(x))
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+        var similarSchoolData = similarSchoolUrns.Length == 0
+            ? Array.Empty<AbsenceData>()
+            : await repository.GetByUrnsAsync(similarSchoolUrns);
 
         var overallSchoolSeries = new AttendanceMeasureSeries(
             ParseNullableDecimal(data?.EstablishmentAbsence?.Abs_Tot_Est_Current_Pct),
@@ -43,22 +53,40 @@ public class GetAttendanceMeasures(
             ParseNullableDecimal(data?.EnglandAbsence?.Abs_Persistent_Eng_Current_Pct),
             ParseNullableDecimal(data?.EnglandAbsence?.Abs_Persistent_Eng_Previous_Pct),
             ParseNullableDecimal(data?.EnglandAbsence?.Abs_Persistent_Eng_Previous2_Pct));
+        var overallSimilarSchoolsSeries = new AttendanceMeasureSeries(
+            AverageAvailable(similarSchoolData.Select(x => ParseNullableDecimal(x.EstablishmentAbsence?.Abs_Tot_Est_Current_Pct))),
+            AverageAvailable(similarSchoolData.Select(x => ParseNullableDecimal(x.EstablishmentAbsence?.Abs_Tot_Est_Previous_Pct))),
+            AverageAvailable(similarSchoolData.Select(x => ParseNullableDecimal(x.EstablishmentAbsence?.Abs_Tot_Est_Previous2_Pct))));
+        var persistentSimilarSchoolsSeries = new AttendanceMeasureSeries(
+            AverageAvailable(similarSchoolData.Select(x => ParseNullableDecimal(x.EstablishmentAbsence?.Abs_Persistent_Est_Current_Pct))),
+            AverageAvailable(similarSchoolData.Select(x => ParseNullableDecimal(x.EstablishmentAbsence?.Abs_Persistent_Est_Previous_Pct))),
+            AverageAvailable(similarSchoolData.Select(x => ParseNullableDecimal(x.EstablishmentAbsence?.Abs_Persistent_Est_Previous2_Pct))));
 
         return new(
             new AttendanceMeasureAverage(
                 Average(overallSchoolSeries.Current, overallSchoolSeries.Previous, overallSchoolSeries.Previous2),
+                AverageAvailable(similarSchoolData.Select(x => Average(
+                    ParseNullableDecimal(x.EstablishmentAbsence?.Abs_Tot_Est_Current_Pct),
+                    ParseNullableDecimal(x.EstablishmentAbsence?.Abs_Tot_Est_Previous_Pct),
+                    ParseNullableDecimal(x.EstablishmentAbsence?.Abs_Tot_Est_Previous2_Pct)))),
                 Average(overallLocalAuthoritySeries.Current, overallLocalAuthoritySeries.Previous, overallLocalAuthoritySeries.Previous2),
                 Average(overallEnglandSeries.Current, overallEnglandSeries.Previous, overallEnglandSeries.Previous2)),
             new AttendanceMeasureYearByYear(
                 overallSchoolSeries,
+                overallSimilarSchoolsSeries,
                 overallLocalAuthoritySeries,
                 overallEnglandSeries),
             new AttendanceMeasureAverage(
                 Average(persistentSchoolSeries.Current, persistentSchoolSeries.Previous, persistentSchoolSeries.Previous2),
+                AverageAvailable(similarSchoolData.Select(x => Average(
+                    ParseNullableDecimal(x.EstablishmentAbsence?.Abs_Persistent_Est_Current_Pct),
+                    ParseNullableDecimal(x.EstablishmentAbsence?.Abs_Persistent_Est_Previous_Pct),
+                    ParseNullableDecimal(x.EstablishmentAbsence?.Abs_Persistent_Est_Previous2_Pct)))),
                 Average(persistentLocalAuthoritySeries.Current, persistentLocalAuthoritySeries.Previous, persistentLocalAuthoritySeries.Previous2),
                 Average(persistentEnglandSeries.Current, persistentEnglandSeries.Previous, persistentEnglandSeries.Previous2)),
             new AttendanceMeasureYearByYear(
                 persistentSchoolSeries,
+                persistentSimilarSchoolsSeries,
                 persistentLocalAuthoritySeries,
                 persistentEnglandSeries));
     }
@@ -84,12 +112,25 @@ public class GetAttendanceMeasures(
 
         return Math.Round(values.Average(v => v!.Value), 2, MidpointRounding.AwayFromZero);
     }
+
+    private static decimal? AverageAvailable(IEnumerable<decimal?> values)
+    {
+        var availableValues = values
+            .Where(v => v.HasValue)
+            .Select(v => v!.Value)
+            .ToList();
+
+        return availableValues.Count == 0
+            ? null
+            : Math.Round(availableValues.Average(), 2, MidpointRounding.AwayFromZero);
+    }
 }
 
 public record GetAttendanceMeasuresRequest(string Urn);
 
 public record AttendanceMeasureAverage(
     decimal? SchoolValue,
+    decimal? SimilarSchoolsValue,
     decimal? LocalAuthorityValue,
     decimal? EnglandValue);
 
@@ -100,6 +141,7 @@ public record AttendanceMeasureSeries(
 
 public record AttendanceMeasureYearByYear(
     AttendanceMeasureSeries School,
+    AttendanceMeasureSeries SimilarSchools,
     AttendanceMeasureSeries LocalAuthority,
     AttendanceMeasureSeries England);
 

--- a/SAPSec.Web/Controllers/SchoolController.cs
+++ b/SAPSec.Web/Controllers/SchoolController.cs
@@ -104,6 +104,9 @@ public class SchoolController : Controller
         var selectedSchoolSeries = isPersistentAbsence
             ? response.PersistentAbsenceYearByYear.School
             : response.OverallAbsenceYearByYear.School;
+        var similarSchoolsSeries = isPersistentAbsence
+            ? response.PersistentAbsenceYearByYear.SimilarSchools
+            : response.OverallAbsenceYearByYear.SimilarSchools;
         var localAuthoritySeries = isPersistentAbsence
             ? response.PersistentAbsenceYearByYear.LocalAuthority
             : response.OverallAbsenceYearByYear.LocalAuthority;
@@ -114,6 +117,9 @@ public class SchoolController : Controller
         var selectedSchoolThreeYearAverage = isPersistentAbsence
             ? response.PersistentAbsenceThreeYearAverage.SchoolValue
             : response.OverallAbsenceThreeYearAverage.SchoolValue;
+        var similarSchoolsThreeYearAverage = isPersistentAbsence
+            ? response.PersistentAbsenceThreeYearAverage.SimilarSchoolsValue
+            : response.OverallAbsenceThreeYearAverage.SimilarSchoolsValue;
         var localAuthorityThreeYearAverage = isPersistentAbsence
             ? response.PersistentAbsenceThreeYearAverage.LocalAuthorityValue
             : response.OverallAbsenceThreeYearAverage.LocalAuthorityValue;
@@ -128,12 +134,14 @@ public class SchoolController : Controller
             bar = new decimal?[]
             {
                 selectedSchoolThreeYearAverage,
+                similarSchoolsThreeYearAverage,
                 localAuthorityThreeYearAverage,
                 englandThreeYearAverage
             },
             line = new
             {
                 school = new decimal?[] { selectedSchoolSeries.Previous2, selectedSchoolSeries.Previous, selectedSchoolSeries.Current },
+                similarSchools = new decimal?[] { similarSchoolsSeries.Previous2, similarSchoolsSeries.Previous, similarSchoolsSeries.Current },
                 localAuthority = new decimal?[] { localAuthoritySeries.Previous2, localAuthoritySeries.Previous, localAuthoritySeries.Current },
                 england = new decimal?[] { englandSeries.Previous2, englandSeries.Previous, englandSeries.Current }
             },
@@ -145,6 +153,13 @@ public class SchoolController : Controller
                     DisplayPercentNullable(selectedSchoolSeries.Previous),
                     DisplayPercentNullable(selectedSchoolSeries.Current),
                     DisplayPercentNullable(selectedSchoolThreeYearAverage)
+                },
+                similarSchools = new[]
+                {
+                    DisplayPercentNullable(similarSchoolsSeries.Previous2),
+                    DisplayPercentNullable(similarSchoolsSeries.Previous),
+                    DisplayPercentNullable(similarSchoolsSeries.Current),
+                    DisplayPercentNullable(similarSchoolsThreeYearAverage)
                 },
                 localAuthority = new[]
                 {

--- a/SAPSec.Web/ViewModels/SchoolAttendancePageViewModel.cs
+++ b/SAPSec.Web/ViewModels/SchoolAttendancePageViewModel.cs
@@ -11,16 +11,19 @@ public class SchoolAttendancePageViewModel
     public required GetAttendanceMeasuresResponse AttendanceMeasures { get; init; }
 
     public string SchoolName => SchoolDetails.Name;
+    public string SimilarSchoolsLabel => "Similar schools average";
     public string LocalAuthorityName => SchoolDetails.LocalAuthorityName.Display();
     public string LocalAuthorityLabel => "Local authority schools average";
     public string EnglandLabel => "Schools in England average";
     public string[] AcademicYears => Ks4YearLabelConfig.YearByYear;
 
     public decimal? SelectedSchoolOverallAbsenceThreeYearAverage => AttendanceMeasures.OverallAbsenceThreeYearAverage.SchoolValue;
+    public decimal? SimilarSchoolsOverallAbsenceThreeYearAverage => AttendanceMeasures.OverallAbsenceThreeYearAverage.SimilarSchoolsValue;
     public decimal? LocalAuthorityOverallAbsenceThreeYearAverage => AttendanceMeasures.OverallAbsenceThreeYearAverage.LocalAuthorityValue;
     public decimal? EnglandOverallAbsenceThreeYearAverage => AttendanceMeasures.OverallAbsenceThreeYearAverage.EnglandValue;
 
     public decimal? SelectedSchoolPersistentAbsenceThreeYearAverage => AttendanceMeasures.PersistentAbsenceThreeYearAverage.SchoolValue;
+    public decimal? SimilarSchoolsPersistentAbsenceThreeYearAverage => AttendanceMeasures.PersistentAbsenceThreeYearAverage.SimilarSchoolsValue;
     public decimal? LocalAuthorityPersistentAbsenceThreeYearAverage => AttendanceMeasures.PersistentAbsenceThreeYearAverage.LocalAuthorityValue;
     public decimal? EnglandPersistentAbsenceThreeYearAverage => AttendanceMeasures.PersistentAbsenceThreeYearAverage.EnglandValue;
 

--- a/SAPSec.Web/Views/School/Attendance.cshtml
+++ b/SAPSec.Web/Views/School/Attendance.cshtml
@@ -8,12 +8,14 @@
         labels = new[]
         {
             Model.SchoolName,
+            Model.SimilarSchoolsLabel,
             Model.LocalAuthorityLabel,
             Model.EnglandLabel
         },
         data = new decimal?[]
         {
             Model.SelectedSchoolOverallAbsenceThreeYearAverage,
+            Model.SimilarSchoolsOverallAbsenceThreeYearAverage,
             Model.LocalAuthorityOverallAbsenceThreeYearAverage,
             Model.EnglandOverallAbsenceThreeYearAverage
         }
@@ -24,12 +26,13 @@
         datasets = new object[]
         {
             new { label = Model.SchoolName, data = new decimal?[] { Model.AttendanceMeasures.OverallAbsenceYearByYear.School.Previous2, Model.AttendanceMeasures.OverallAbsenceYearByYear.School.Previous, Model.AttendanceMeasures.OverallAbsenceYearByYear.School.Current }, tension = 0, borderWidth = 2, pointRadius = 4, pointHoverRadius = 5 },
+            new { label = Model.SimilarSchoolsLabel, data = new decimal?[] { Model.AttendanceMeasures.OverallAbsenceYearByYear.SimilarSchools.Previous2, Model.AttendanceMeasures.OverallAbsenceYearByYear.SimilarSchools.Previous, Model.AttendanceMeasures.OverallAbsenceYearByYear.SimilarSchools.Current }, tension = 0, borderWidth = 2, pointRadius = 4, pointHoverRadius = 5 },
             new { label = Model.LocalAuthorityLabel, data = new decimal?[] { Model.AttendanceMeasures.OverallAbsenceYearByYear.LocalAuthority.Previous2, Model.AttendanceMeasures.OverallAbsenceYearByYear.LocalAuthority.Previous, Model.AttendanceMeasures.OverallAbsenceYearByYear.LocalAuthority.Current }, tension = 0, borderWidth = 2, pointRadius = 4, pointHoverRadius = 5 },
             new { label = Model.EnglandLabel, data = new decimal?[] { Model.AttendanceMeasures.OverallAbsenceYearByYear.England.Previous2, Model.AttendanceMeasures.OverallAbsenceYearByYear.England.Previous, Model.AttendanceMeasures.OverallAbsenceYearByYear.England.Current }, tension = 0, borderWidth = 2, pointRadius = 4, pointHoverRadius = 5 }
         }
     };
-    var chartColors = new[] { "#D53780", "#003078", "#003078" };
-    var lineChartColors = new[] { "#D53780", "#5694CA", "#28A197" };
+    var chartColors = new[] { "#D53780", "#2a1950", "#003078", "#28A197" };
+    var lineChartColors = new[] { "#D53780", "#2a1950", "#5694CA", "#28A197" };
     var attendanceDataEndpoint = Url.Action("AttendanceData", "School", new { urn = Model.SchoolDetails.Urn });
 }
 
@@ -40,18 +43,10 @@
     Compare this school's attendance measures with:
 </p>
 <ul class="govuk-list govuk-list--bullet">
+    <li>similar schools average</li>
     <li>the local authority average</li>
     <li>the national average</li>
 </ul>
-
-<div class="govuk-inset-text">
-    <p class="govuk-body">
-        To compare your school's attendance with similar schools, use the Monitor your school attendance service.
-    </p>
-    <p class="govuk-body govuk-!-margin-bottom-0">
-        You can access this service on <a href="https://viewyourdata.education.gov.uk/" class="govuk-link" target="_blank" rel="noopener noreferrer">View your education data (VYED)</a>. If you do not have VYED access, <a href="https://viewyourdata.education.gov.uk/Account/Help" class="govuk-link" target="_blank" rel="noopener noreferrer">you can follow this guidance</a>.
-    </p>
-</div>
 
 <section aria-labelledby="attendance-heading" class="govuk-!-margin-top-9 app-ks4-attainment">
     <h2 class="govuk-heading-m" id="attendance-heading">Attendance</h2>
@@ -68,8 +63,8 @@
                     data-bar-chart-id="school-attendance-three-year-chart"
                     data-line-chart-id="school-attendance-year-by-year-chart"
                     data-cell-attribute="data-attendance-cell"
-                    data-cell-prefixes='{"school":"school","localAuthority":"la","england":"england"}'
-                    data-series-keys='["school","localAuthority","england"]'>
+                    data-cell-prefixes='{"school":"school","similarSchools":"similar","localAuthority":"la","england":"england"}'
+                    data-series-keys='["school","similarSchools","localAuthority","england"]'>
                 <option value="overall" selected>Overall absence</option>
                 <option value="persistent">Persistent absence</option>
             </select>
@@ -143,6 +138,13 @@
                     <td class="govuk-table__cell govuk-table__cell--numeric" data-attendance-cell="school-prev">@SAPSec.Web.ViewModels.SchoolAttendancePageViewModel.DisplayPercentNullable(Model.AttendanceMeasures.OverallAbsenceYearByYear.School.Previous)</td>
                     <td class="govuk-table__cell govuk-table__cell--numeric" data-attendance-cell="school-current">@SAPSec.Web.ViewModels.SchoolAttendancePageViewModel.DisplayPercentNullable(Model.AttendanceMeasures.OverallAbsenceYearByYear.School.Current)</td>
                     <td class="govuk-table__cell govuk-table__cell--numeric" data-attendance-cell="school-avg">@SAPSec.Web.ViewModels.SchoolAttendancePageViewModel.DisplayPercentNullable(Model.SelectedSchoolOverallAbsenceThreeYearAverage)</td>
+                </tr>
+                <tr class="govuk-table__row">
+                    <th scope="row" class="govuk-table__header">@Model.SimilarSchoolsLabel</th>
+                    <td class="govuk-table__cell govuk-table__cell--numeric" data-attendance-cell="similar-prev2">@SAPSec.Web.ViewModels.SchoolAttendancePageViewModel.DisplayPercentNullable(Model.AttendanceMeasures.OverallAbsenceYearByYear.SimilarSchools.Previous2)</td>
+                    <td class="govuk-table__cell govuk-table__cell--numeric" data-attendance-cell="similar-prev">@SAPSec.Web.ViewModels.SchoolAttendancePageViewModel.DisplayPercentNullable(Model.AttendanceMeasures.OverallAbsenceYearByYear.SimilarSchools.Previous)</td>
+                    <td class="govuk-table__cell govuk-table__cell--numeric" data-attendance-cell="similar-current">@SAPSec.Web.ViewModels.SchoolAttendancePageViewModel.DisplayPercentNullable(Model.AttendanceMeasures.OverallAbsenceYearByYear.SimilarSchools.Current)</td>
+                    <td class="govuk-table__cell govuk-table__cell--numeric" data-attendance-cell="similar-avg">@SAPSec.Web.ViewModels.SchoolAttendancePageViewModel.DisplayPercentNullable(Model.SimilarSchoolsOverallAbsenceThreeYearAverage)</td>
                 </tr>
                 <tr class="govuk-table__row">
                     <th scope="row" class="govuk-table__header">@Model.LocalAuthorityLabel</th>

--- a/SAPSec.Web/Views/School/Attendance.cshtml
+++ b/SAPSec.Web/Views/School/Attendance.cshtml
@@ -31,7 +31,7 @@
             new { label = Model.EnglandLabel, data = new decimal?[] { Model.AttendanceMeasures.OverallAbsenceYearByYear.England.Previous2, Model.AttendanceMeasures.OverallAbsenceYearByYear.England.Previous, Model.AttendanceMeasures.OverallAbsenceYearByYear.England.Current }, tension = 0, borderWidth = 2, pointRadius = 4, pointHoverRadius = 5 }
         }
     };
-    var chartColors = new[] { "#D53780", "#2a1950", "#2a1950", "#003078" };
+    var chartColors = new[] { "#D53780", "#2a1950", "#2a1950", "#2a1950" };
     var lineChartColors = new[] { "#D53780", "#2a1950", "#5694CA", "#28A197" };
     var attendanceDataEndpoint = Url.Action("AttendanceData", "School", new { urn = Model.SchoolDetails.Urn });
 }

--- a/SAPSec.Web/Views/School/Attendance.cshtml
+++ b/SAPSec.Web/Views/School/Attendance.cshtml
@@ -31,7 +31,7 @@
             new { label = Model.EnglandLabel, data = new decimal?[] { Model.AttendanceMeasures.OverallAbsenceYearByYear.England.Previous2, Model.AttendanceMeasures.OverallAbsenceYearByYear.England.Previous, Model.AttendanceMeasures.OverallAbsenceYearByYear.England.Current }, tension = 0, borderWidth = 2, pointRadius = 4, pointHoverRadius = 5 }
         }
     };
-    var chartColors = new[] { "#D53780", "#2a1950", "#003078", "#003078" };
+    var chartColors = new[] { "#D53780", "#2a1950", "#2a1950", "#003078" };
     var lineChartColors = new[] { "#D53780", "#2a1950", "#5694CA", "#28A197" };
     var attendanceDataEndpoint = Url.Action("AttendanceData", "School", new { urn = Model.SchoolDetails.Urn });
 }
@@ -53,7 +53,7 @@
 
     <div class="app-ks4-filter-row govuk-!-margin-bottom-6">
         <div class="govuk-form-group">
-            <label class="govuk-label" for="attendanceAbsenceType">Type of absence</label>
+            <label class="govuk-label govuk-label--s" for="attendanceAbsenceType">Type of absence</label>
             <select class="govuk-select"
                     id="attendanceAbsenceType"
                     name="attendanceAbsenceType"

--- a/SAPSec.Web/Views/School/Attendance.cshtml
+++ b/SAPSec.Web/Views/School/Attendance.cshtml
@@ -43,10 +43,14 @@
     Compare this school's attendance measures with:
 </p>
 <ul class="govuk-list govuk-list--bullet">
-    <li>similar schools average</li>
+    <li><b>50</b> similar secondary phase schools (including all-throughs)</li>
     <li>the local authority average</li>
     <li>the national average</li>
 </ul>
+
+<p class="govuk-body">
+    Find out <a href="/school/@Model.SchoolDetails.Urn/what-is-a-similar-school" class="govuk-link">how DfE defines what a similar school is</a>.
+</p>
 
 <section aria-labelledby="attendance-heading" class="govuk-!-margin-top-9 app-ks4-attainment">
     <h2 class="govuk-heading-m" id="attendance-heading">Attendance</h2>

--- a/SAPSec.Web/Views/School/Attendance.cshtml
+++ b/SAPSec.Web/Views/School/Attendance.cshtml
@@ -31,7 +31,7 @@
             new { label = Model.EnglandLabel, data = new decimal?[] { Model.AttendanceMeasures.OverallAbsenceYearByYear.England.Previous2, Model.AttendanceMeasures.OverallAbsenceYearByYear.England.Previous, Model.AttendanceMeasures.OverallAbsenceYearByYear.England.Current }, tension = 0, borderWidth = 2, pointRadius = 4, pointHoverRadius = 5 }
         }
     };
-    var chartColors = new[] { "#D53780", "#2a1950", "#003078", "#28A197" };
+    var chartColors = new[] { "#D53780", "#2a1950", "#003078", "#003078" };
     var lineChartColors = new[] { "#D53780", "#2a1950", "#5694CA", "#28A197" };
     var attendanceDataEndpoint = Url.Action("AttendanceData", "School", new { urn = Model.SchoolDetails.Urn });
 }

--- a/SAPSec.Web/Views/SimilarSchoolsComparison/Attendance.cshtml
+++ b/SAPSec.Web/Views/SimilarSchoolsComparison/Attendance.cshtml
@@ -36,7 +36,7 @@
 
     <div class="app-ks4-filter-row govuk-!-margin-bottom-6">
         <div class="govuk-form-group">
-            <label class="govuk-label" for="attendanceAbsenceType">Type of absence</label>
+            <label class="govuk-label govuk-label--s" for="attendanceAbsenceType">Type of absence</label>
             <select class="govuk-select"
                     id="attendanceAbsenceType"
                     name="attendanceAbsenceType"

--- a/SAPSec.Web/Views/SimilarSchoolsComparison/Attendance.cshtml
+++ b/SAPSec.Web/Views/SimilarSchoolsComparison/Attendance.cshtml
@@ -20,7 +20,7 @@
             new { label = "Schools in England average", data = Array.Empty<decimal?>(), tension = 0, borderWidth = 2, pointRadius = 4, pointHoverRadius = 5 }
         }
     };
-    var chartColors = new[] { "#d53880", "#003078", "#003078" };
+    var chartColors = new[] { "#d53880", "#2a1950", "#2a1950" };
     var lineChartColors = new[] { "#D53780", "#003078", "#28A197" };
     var attendanceDataEndpoint = Url.Action("AttendanceData", "SimilarSchoolsComparison",
         new { urn = Model.Urn, similarSchoolUrn = Model.SimilarSchoolUrn });

--- a/Tests/SAPSec.Core.Tests/Features/Attendance/UseCases/GetAttendanceMeasuresTests.cs
+++ b/Tests/SAPSec.Core.Tests/Features/Attendance/UseCases/GetAttendanceMeasuresTests.cs
@@ -1,6 +1,7 @@
 using Moq;
 using SAPSec.Core.Features.Attendance;
 using SAPSec.Core.Features.Attendance.UseCases;
+using SAPSec.Core.Features.SimilarSchools;
 using SAPSec.Core.Interfaces.Repositories;
 using SAPSec.Core.Model.Generated;
 
@@ -13,12 +14,16 @@ public class GetAttendanceMeasuresTests
     {
         var establishmentRepositoryMock = new Mock<IEstablishmentRepository>();
         var repositoryMock = new Mock<IAbsenceRepository>();
+        var similarSchoolsRepositoryMock = new Mock<ISimilarSchoolsSecondaryRepository>();
 
         establishmentRepositoryMock
             .Setup(x => x.GetEstablishmentAsync("999999"))
             .ReturnsAsync((Establishment?)null);
+        similarSchoolsRepositoryMock
+            .Setup(x => x.GetSimilarSchoolsGroupAsync(It.IsAny<string>()))
+            .ReturnsAsync(Array.Empty<SimilarSchoolsSecondaryGroupsEntry>());
 
-        var sut = new GetAttendanceMeasures(repositoryMock.Object, establishmentRepositoryMock.Object);
+        var sut = new GetAttendanceMeasures(repositoryMock.Object, establishmentRepositoryMock.Object, similarSchoolsRepositoryMock.Object);
 
         var act = async () => await sut.Execute(new GetAttendanceMeasuresRequest("999999"));
 
@@ -31,6 +36,7 @@ public class GetAttendanceMeasuresTests
     {
         var establishmentRepositoryMock = new Mock<IEstablishmentRepository>();
         var repositoryMock = new Mock<IAbsenceRepository>();
+        var similarSchoolsRepositoryMock = new Mock<ISimilarSchoolsSecondaryRepository>();
 
         establishmentRepositoryMock
             .Setup(x => x.GetEstablishmentAsync("123456"))
@@ -67,18 +73,60 @@ public class GetAttendanceMeasuresTests
                     Abs_Persistent_Eng_Previous_Pct = "15.8",
                     Abs_Persistent_Eng_Previous2_Pct = "16.0"
                 }));
+        similarSchoolsRepositoryMock
+            .Setup(x => x.GetSimilarSchoolsGroupAsync("123456"))
+            .ReturnsAsync(
+            [
+                new SimilarSchoolsSecondaryGroupsEntry { URN = "123456", NeighbourURN = "200001" },
+                new SimilarSchoolsSecondaryGroupsEntry { URN = "123456", NeighbourURN = "200002" }
+            ]);
+        repositoryMock
+            .Setup(x => x.GetByUrnsAsync(It.Is<IEnumerable<string>>(urns => urns.SequenceEqual(new[] { "200001", "200002" }))))
+            .ReturnsAsync(
+            [
+                new AbsenceData(
+                    "200001",
+                    new EstablishmentAbsence
+                    {
+                        Abs_Tot_Est_Current_Pct = "6.0",
+                        Abs_Tot_Est_Previous_Pct = "6.2",
+                        Abs_Tot_Est_Previous2_Pct = "6.4",
+                        Abs_Persistent_Est_Current_Pct = "18.0",
+                        Abs_Persistent_Est_Previous_Pct = "18.4",
+                        Abs_Persistent_Est_Previous2_Pct = "18.8"
+                    },
+                    null,
+                    null,
+                    null),
+                new AbsenceData(
+                    "200002",
+                    new EstablishmentAbsence
+                    {
+                        Abs_Tot_Est_Current_Pct = "5.0",
+                        Abs_Tot_Est_Previous_Pct = "5.2",
+                        Abs_Tot_Est_Previous2_Pct = "5.4",
+                        Abs_Persistent_Est_Current_Pct = "17.0",
+                        Abs_Persistent_Est_Previous_Pct = "17.4",
+                        Abs_Persistent_Est_Previous2_Pct = "17.8"
+                    },
+                    null,
+                    null,
+                    null)
+            ]);
 
-        var sut = new GetAttendanceMeasures(repositoryMock.Object, establishmentRepositoryMock.Object);
+        var sut = new GetAttendanceMeasures(repositoryMock.Object, establishmentRepositoryMock.Object, similarSchoolsRepositoryMock.Object);
 
         var result = await sut.Execute(new GetAttendanceMeasuresRequest("123456"));
 
-        result.OverallAbsenceThreeYearAverage.Should().Be(new AttendanceMeasureAverage(5.2m, 4.83m, 4.9m));
+        result.OverallAbsenceThreeYearAverage.Should().Be(new AttendanceMeasureAverage(5.2m, 5.7m, 4.83m, 4.9m));
         result.OverallAbsenceYearByYear.School.Should().Be(new AttendanceMeasureSeries(5.0m, 5.2m, 5.4m));
+        result.OverallAbsenceYearByYear.SimilarSchools.Should().Be(new AttendanceMeasureSeries(5.5m, 5.7m, 5.9m));
         result.OverallAbsenceYearByYear.LocalAuthority.Should().Be(new AttendanceMeasureSeries(4.7m, 4.8m, 5.0m));
         result.OverallAbsenceYearByYear.England.Should().Be(new AttendanceMeasureSeries(4.8m, 4.9m, 5.0m));
 
-        result.PersistentAbsenceThreeYearAverage.Should().Be(new AttendanceMeasureAverage(16.4m, 15.3m, 15.83m));
+        result.PersistentAbsenceThreeYearAverage.Should().Be(new AttendanceMeasureAverage(16.4m, 17.9m, 15.3m, 15.83m));
         result.PersistentAbsenceYearByYear.School.Should().Be(new AttendanceMeasureSeries(16.0m, 16.4m, 16.8m));
+        result.PersistentAbsenceYearByYear.SimilarSchools.Should().Be(new AttendanceMeasureSeries(17.5m, 17.9m, 18.3m));
         result.PersistentAbsenceYearByYear.LocalAuthority.Should().Be(new AttendanceMeasureSeries(15.1m, 15.3m, 15.5m));
         result.PersistentAbsenceYearByYear.England.Should().Be(new AttendanceMeasureSeries(15.7m, 15.8m, 16.0m));
     }
@@ -88,25 +136,31 @@ public class GetAttendanceMeasuresTests
     {
         var establishmentRepositoryMock = new Mock<IEstablishmentRepository>();
         var repositoryMock = new Mock<IAbsenceRepository>();
+        var similarSchoolsRepositoryMock = new Mock<ISimilarSchoolsSecondaryRepository>();
 
         establishmentRepositoryMock
             .Setup(x => x.GetEstablishmentAsync("123456"))
             .ReturnsAsync(new Establishment { URN = "123456" });
+        similarSchoolsRepositoryMock
+            .Setup(x => x.GetSimilarSchoolsGroupAsync(It.IsAny<string>()))
+            .ReturnsAsync(Array.Empty<SimilarSchoolsSecondaryGroupsEntry>());
 
         repositoryMock
             .Setup(x => x.GetByUrnAsync("123456"))
             .ReturnsAsync((AbsenceData?)null);
 
-        var sut = new GetAttendanceMeasures(repositoryMock.Object, establishmentRepositoryMock.Object);
+        var sut = new GetAttendanceMeasures(repositoryMock.Object, establishmentRepositoryMock.Object, similarSchoolsRepositoryMock.Object);
 
         var result = await sut.Execute(new GetAttendanceMeasuresRequest("123456"));
 
-        result.OverallAbsenceThreeYearAverage.Should().Be(new AttendanceMeasureAverage(null, null, null));
+        result.OverallAbsenceThreeYearAverage.Should().Be(new AttendanceMeasureAverage(null, null, null, null));
         result.OverallAbsenceYearByYear.School.Should().Be(new AttendanceMeasureSeries(null, null, null));
+        result.OverallAbsenceYearByYear.SimilarSchools.Should().Be(new AttendanceMeasureSeries(null, null, null));
         result.OverallAbsenceYearByYear.LocalAuthority.Should().Be(new AttendanceMeasureSeries(null, null, null));
         result.OverallAbsenceYearByYear.England.Should().Be(new AttendanceMeasureSeries(null, null, null));
-        result.PersistentAbsenceThreeYearAverage.Should().Be(new AttendanceMeasureAverage(null, null, null));
+        result.PersistentAbsenceThreeYearAverage.Should().Be(new AttendanceMeasureAverage(null, null, null, null));
         result.PersistentAbsenceYearByYear.School.Should().Be(new AttendanceMeasureSeries(null, null, null));
+        result.PersistentAbsenceYearByYear.SimilarSchools.Should().Be(new AttendanceMeasureSeries(null, null, null));
         result.PersistentAbsenceYearByYear.LocalAuthority.Should().Be(new AttendanceMeasureSeries(null, null, null));
         result.PersistentAbsenceYearByYear.England.Should().Be(new AttendanceMeasureSeries(null, null, null));
     }
@@ -116,10 +170,14 @@ public class GetAttendanceMeasuresTests
     {
         var establishmentRepositoryMock = new Mock<IEstablishmentRepository>();
         var repositoryMock = new Mock<IAbsenceRepository>();
+        var similarSchoolsRepositoryMock = new Mock<ISimilarSchoolsSecondaryRepository>();
 
         establishmentRepositoryMock
             .Setup(x => x.GetEstablishmentAsync("123456"))
             .ReturnsAsync(new Establishment { URN = "123456", LAId = "373" });
+        similarSchoolsRepositoryMock
+            .Setup(x => x.GetSimilarSchoolsGroupAsync(It.IsAny<string>()))
+            .ReturnsAsync(Array.Empty<SimilarSchoolsSecondaryGroupsEntry>());
 
         repositoryMock
             .Setup(x => x.GetByUrnAsync("123456"))
@@ -153,12 +211,12 @@ public class GetAttendanceMeasuresTests
                     Abs_Persistent_Eng_Previous2_Pct = "16.0"
                 }));
 
-        var sut = new GetAttendanceMeasures(repositoryMock.Object, establishmentRepositoryMock.Object);
+        var sut = new GetAttendanceMeasures(repositoryMock.Object, establishmentRepositoryMock.Object, similarSchoolsRepositoryMock.Object);
 
         var result = await sut.Execute(new GetAttendanceMeasuresRequest("123456"));
 
-        result.OverallAbsenceThreeYearAverage.Should().Be(new AttendanceMeasureAverage(null, null, null));
-        result.PersistentAbsenceThreeYearAverage.Should().Be(new AttendanceMeasureAverage(null, null, null));
+        result.OverallAbsenceThreeYearAverage.Should().Be(new AttendanceMeasureAverage(null, null, null, null));
+        result.PersistentAbsenceThreeYearAverage.Should().Be(new AttendanceMeasureAverage(null, null, null, null));
     }
 
 }

--- a/Tests/SAPSec.Core.Tests/Features/Attendance/UseCases/GetAttendanceMeasuresTests.cs
+++ b/Tests/SAPSec.Core.Tests/Features/Attendance/UseCases/GetAttendanceMeasuresTests.cs
@@ -96,7 +96,6 @@ public class GetAttendanceMeasuresTests
                         Abs_Persistent_Est_Previous2_Pct = "18.8"
                     },
                     null,
-                    null,
                     null),
                 new AbsenceData(
                     "200002",
@@ -109,7 +108,6 @@ public class GetAttendanceMeasuresTests
                         Abs_Persistent_Est_Previous_Pct = "17.4",
                         Abs_Persistent_Est_Previous2_Pct = "17.8"
                     },
-                    null,
                     null,
                     null)
             ]);

--- a/Tests/SAPSec.UI.Tests/SchoolAttendancePageTests.cs
+++ b/Tests/SAPSec.UI.Tests/SchoolAttendancePageTests.cs
@@ -32,9 +32,9 @@ public class SchoolAttendancePageTests(WebApplicationSetupFixture fixture) : Bas
         await NavigateToAttendanceAsync();
 
         await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = "Attendance measures" })).ToBeVisibleAsync();
+        await Expect(Page.Locator("main")).ToContainTextAsync("similar schools average");
         await Expect(Page.Locator("main")).ToContainTextAsync("the local authority average");
         await Expect(Page.Locator("main")).ToContainTextAsync("the national average");
-        await Expect(Page.Locator("main")).ToContainTextAsync("Monitor your school attendance service");
         await Expect(Page.Locator("#school-attendance-three-year-chart")).ToBeVisibleAsync();
         await Expect(Page.Locator("#school-attendance-three-year-chart")).ToHaveAttributeAsync("data-show-no-data-labels", "true");
         await Expect(Page.Locator(".app-attendance-tabs .govuk-tabs__tab[href='#attendance-year-by-year']")).ToBeVisibleAsync();
@@ -53,17 +53,6 @@ public class SchoolAttendancePageTests(WebApplicationSetupFixture fixture) : Bas
         await Expect(activeLink).ToBeVisibleAsync();
         await Expect(activeLink).ToHaveAttributeAsync("href", "/school/145327/attendance");
         await Expect(activeLink).ToHaveAttributeAsync("aria-current", "page");
-    }
-
-    [Fact]
-    public async Task Attendance_ExternalLinksOpenInNewTab()
-    {
-        await NavigateToAttendanceAsync();
-
-        await Expect(Page.GetByRole(AriaRole.Link, new() { Name = "View your education data (VYED)" }))
-            .ToHaveAttributeAsync("target", "_blank");
-        await Expect(Page.GetByRole(AriaRole.Link, new() { Name = "you can follow this guidance" }))
-            .ToHaveAttributeAsync("target", "_blank");
     }
 
     [Fact]
@@ -126,5 +115,6 @@ public class SchoolAttendancePageTests(WebApplicationSetupFixture fixture) : Bas
         var tableTab = Page.Locator(".app-attendance-tabs .govuk-tabs__tab[href='#attendance-table']");
         await tableTab.ClickAsync();
         await Expect(Page.Locator("#attendance-table .govuk-table")).ToBeVisibleAsync();
+        await Expect(Page.Locator("#attendance-table .govuk-table")).ToContainTextAsync("Similar schools average");
     }
 }

--- a/Tests/SAPSec.UI.Tests/SchoolAttendancePageTests.cs
+++ b/Tests/SAPSec.UI.Tests/SchoolAttendancePageTests.cs
@@ -32,9 +32,11 @@ public class SchoolAttendancePageTests(WebApplicationSetupFixture fixture) : Bas
         await NavigateToAttendanceAsync();
 
         await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = "Attendance measures" })).ToBeVisibleAsync();
-        await Expect(Page.Locator("main")).ToContainTextAsync("similar schools average");
+        await Expect(Page.Locator("main")).ToContainTextAsync("50 similar secondary phase schools (including all-throughs)");
         await Expect(Page.Locator("main")).ToContainTextAsync("the local authority average");
         await Expect(Page.Locator("main")).ToContainTextAsync("the national average");
+        await Expect(Page.GetByRole(AriaRole.Link, new() { Name = "how DfE defines what a similar school is" }))
+            .ToHaveAttributeAsync("href", "/school/145327/what-is-a-similar-school");
         await Expect(Page.Locator("#school-attendance-three-year-chart")).ToBeVisibleAsync();
         await Expect(Page.Locator("#school-attendance-three-year-chart")).ToHaveAttributeAsync("data-show-no-data-labels", "true");
         await Expect(Page.Locator("#school-attendance-three-year-chart")).ToHaveAttributeAsync("data-colors", "[\"#D53780\",\"#2a1950\",\"#2a1950\",\"#2a1950\"]");

--- a/Tests/SAPSec.UI.Tests/SchoolAttendancePageTests.cs
+++ b/Tests/SAPSec.UI.Tests/SchoolAttendancePageTests.cs
@@ -37,7 +37,7 @@ public class SchoolAttendancePageTests(WebApplicationSetupFixture fixture) : Bas
         await Expect(Page.Locator("main")).ToContainTextAsync("the national average");
         await Expect(Page.Locator("#school-attendance-three-year-chart")).ToBeVisibleAsync();
         await Expect(Page.Locator("#school-attendance-three-year-chart")).ToHaveAttributeAsync("data-show-no-data-labels", "true");
-        await Expect(Page.Locator("#school-attendance-three-year-chart")).ToHaveAttributeAsync("data-colors", "[\"#D53780\",\"#2a1950\",\"#2a1950\",\"#003078\"]");
+        await Expect(Page.Locator("#school-attendance-three-year-chart")).ToHaveAttributeAsync("data-colors", "[\"#D53780\",\"#2a1950\",\"#2a1950\",\"#2a1950\"]");
         await Expect(Page.Locator(".app-attendance-tabs .govuk-tabs__tab[href='#attendance-year-by-year']")).ToBeVisibleAsync();
         await Expect(Page.Locator(".app-attendance-tabs .govuk-tabs__tab[href='#attendance-table']")).ToBeVisibleAsync();
         await Expect(Page.Locator("label[for='attendanceAbsenceType']")).ToHaveClassAsync(new Regex("govuk-label--s"));

--- a/Tests/SAPSec.UI.Tests/SchoolAttendancePageTests.cs
+++ b/Tests/SAPSec.UI.Tests/SchoolAttendancePageTests.cs
@@ -37,8 +37,10 @@ public class SchoolAttendancePageTests(WebApplicationSetupFixture fixture) : Bas
         await Expect(Page.Locator("main")).ToContainTextAsync("the national average");
         await Expect(Page.Locator("#school-attendance-three-year-chart")).ToBeVisibleAsync();
         await Expect(Page.Locator("#school-attendance-three-year-chart")).ToHaveAttributeAsync("data-show-no-data-labels", "true");
+        await Expect(Page.Locator("#school-attendance-three-year-chart")).ToHaveAttributeAsync("data-colors", "[\"#D53780\",\"#2a1950\",\"#2a1950\",\"#003078\"]");
         await Expect(Page.Locator(".app-attendance-tabs .govuk-tabs__tab[href='#attendance-year-by-year']")).ToBeVisibleAsync();
         await Expect(Page.Locator(".app-attendance-tabs .govuk-tabs__tab[href='#attendance-table']")).ToBeVisibleAsync();
+        await Expect(Page.Locator("label[for='attendanceAbsenceType']")).ToHaveClassAsync(new Regex("govuk-label--s"));
         await Expect(Page.Locator("#attendanceAbsenceType")).ToHaveValueAsync("overall");
     }
 

--- a/Tests/SAPSec.UI.Tests/SimilarSchoolsComparisonAttendancePageTests.cs
+++ b/Tests/SAPSec.UI.Tests/SimilarSchoolsComparisonAttendancePageTests.cs
@@ -21,6 +21,7 @@ public class SimilarSchoolsComparisonAttendancePageTests(WebApplicationSetupFixt
         await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
         await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = "Attendance measures" })).ToBeVisibleAsync();
+        await Expect(Page.Locator("label[for='attendanceAbsenceType']")).ToHaveClassAsync(new Regex("govuk-label--s"));
 
         var absenceType = Page.Locator("#attendanceAbsenceType");
         await Expect(absenceType).ToHaveValueAsync("overall");

--- a/Tests/SAPSec.Web.Tests/Controllers/SchoolControllerTests.cs
+++ b/Tests/SAPSec.Web.Tests/Controllers/SchoolControllerTests.cs
@@ -13,6 +13,7 @@ using SAPSec.Core.Interfaces.Services;
 using SAPSec.Core.Model;
 using SAPSec.Core.Model.Generated;
 using SAPSec.Web.Controllers;
+using System.Text.Json;
 
 namespace SAPSec.Web.Tests.Controllers;
 
@@ -45,7 +46,8 @@ public class SchoolControllerTests
 
         var getAttendanceMeasures = new GetAttendanceMeasures(
             _absenceRepositoryMock.Object,
-            _establishmentRepositoryMock.Object);
+            _establishmentRepositoryMock.Object,
+            _similarSchoolsRepositoryMock.Object);
         var getSchoolKs4HeadlineMeasures = new GetSchoolKs4HeadlineMeasures(
             _ks4PerformanceRepositoryMock.Object,
             _ks4DestinationsRepositoryMock.Object,
@@ -272,6 +274,9 @@ public class SchoolControllerTests
                 new EstablishmentAbsence(),
                 new LAAbsence(),
                 new EnglandAbsence()));
+        _similarSchoolsRepositoryMock
+            .Setup(x => x.GetSimilarSchoolsGroupAsync(urn))
+            .ReturnsAsync(Array.Empty<SimilarSchoolsSecondaryGroupsEntry>());
 
         var result = await _sut.Attendance(urn);
 
@@ -320,11 +325,55 @@ public class SchoolControllerTests
                     Abs_Persistent_Eng_Previous_Pct = "14.9",
                     Abs_Persistent_Eng_Previous2_Pct = "14.7"
                 }));
+        _similarSchoolsRepositoryMock
+            .Setup(x => x.GetSimilarSchoolsGroupAsync(urn))
+            .ReturnsAsync(
+            [
+                new SimilarSchoolsSecondaryGroupsEntry { URN = urn, NeighbourURN = "200001" },
+                new SimilarSchoolsSecondaryGroupsEntry { URN = urn, NeighbourURN = "200002" }
+            ]);
+        _absenceRepositoryMock
+            .Setup(x => x.GetByUrnsAsync(It.Is<IEnumerable<string>>(urns => urns.SequenceEqual(new[] { "200001", "200002" }))))
+            .ReturnsAsync(
+            [
+                new AbsenceData(
+                    "200001",
+                    new EstablishmentAbsence
+                    {
+                        Abs_Tot_Est_Current_Pct = "5.5",
+                        Abs_Tot_Est_Previous_Pct = "5.4",
+                        Abs_Tot_Est_Previous2_Pct = "5.3",
+                        Abs_Persistent_Est_Current_Pct = "16.5",
+                        Abs_Persistent_Est_Previous_Pct = "16.3",
+                        Abs_Persistent_Est_Previous2_Pct = "16.1"
+                    },
+                    null,
+                    null),
+                new AbsenceData(
+                    "200002",
+                    new EstablishmentAbsence
+                    {
+                        Abs_Tot_Est_Current_Pct = "5.3",
+                        Abs_Tot_Est_Previous_Pct = "5.2",
+                        Abs_Tot_Est_Previous2_Pct = "5.1",
+                        Abs_Persistent_Est_Current_Pct = "16.1",
+                        Abs_Persistent_Est_Previous_Pct = "15.9",
+                        Abs_Persistent_Est_Previous2_Pct = "15.7"
+                    },
+                    null,
+                    null)
+            ]);
 
         var result = await _sut.AttendanceData(urn, "overall");
 
         var json = result.Should().BeOfType<JsonResult>().Subject;
-        json.Value.Should().NotBeNull();
+        var payload = JsonSerializer.Serialize(json.Value);
+        using var document = JsonDocument.Parse(payload);
+        var root = document.RootElement;
+
+        root.GetProperty("bar").GetArrayLength().Should().Be(4);
+        root.GetProperty("line").GetProperty("similarSchools").GetArrayLength().Should().Be(3);
+        root.GetProperty("table").GetProperty("similarSchools").GetArrayLength().Should().Be(4);
     }
 
     #endregion

--- a/Tests/SAPSec.Web.Tests/Controllers/SimilarSchoolsComparisonControllerTests.cs
+++ b/Tests/SAPSec.Web.Tests/Controllers/SimilarSchoolsComparisonControllerTests.cs
@@ -58,7 +58,8 @@ public class SimilarSchoolsComparisonControllerTests
             _repoMock.Object);
         var attendanceUseCase = new GetAttendanceMeasures(
             _absenceRepositoryMock.Object,
-            _establishmentRepositoryMock.Object);
+            _establishmentRepositoryMock.Object,
+            _repoMock.Object);
 
         var getCharacteristicsComparison = new GetCharacteristicsComparison(
             _repoMock.Object);
@@ -77,6 +78,9 @@ public class SimilarSchoolsComparisonControllerTests
                 PercentageStatementOrEHP = 1.678816m,
                 KS2AVG = 2.527329m
             });
+        _repoMock
+            .Setup(r => r.GetSimilarSchoolsGroupAsync(It.IsAny<string>()))
+            .ReturnsAsync(Array.Empty<SimilarSchoolsSecondaryGroupsEntry>());
 
         var characteristicsFormatter = new CharacteristicsComparisonFormatter();
 


### PR DESCRIPTION
https://trello.com/c/HJvXV8pU

This PR adds similar schools data to the attendance page, so schools can compare their attendance with similar schools, the local authority, and England in the charts and table.
It also updates the attendance page styling and tests, including the bold “Type of absence” label and the latest chart colour expectations.

-updated text as well (not part of ticket)
50 similar secondary phase schools (including all-throughs)
the local authority average
the national average
Find out [how DfE defines what a similar school is](https://get-school-improvement-insights-pr-212.test.teacherservices.cloud/school/145327/what-is-a-similar-school).