### PR TITLE
v2 Fixed typo on home page: "premimum"

### DIFF
--- a/SAPSec.Web/Views/Home/Index.cshtml
+++ b/SAPSec.Web/Views/Home/Index.cshtml
@@ -28,7 +28,7 @@
 
                 <ul class="govuk-list govuk-list--bullet">
                     <li>total number of pupils</li>
-                    <li>eligibility for pupil premimum</li>
+                    <li>eligibility for pupil premium</li>
                     <li>percentage of pupils with SEN support</li>
                 </ul>
 


### PR DESCRIPTION
Fixed typo on home page: "premimum"
