### PR TITLE
Add top performers tab to attendance page

### DIFF
--- a/SAPSec.Core/Features/Attendance/UseCases/GetAttendanceMeasures.cs
+++ b/SAPSec.Core/Features/Attendance/UseCases/GetAttendanceMeasures.cs
@@ -26,6 +26,23 @@ public class GetAttendanceMeasures(
         var similarSchoolData = similarSchoolUrns.Length == 0
             ? Array.Empty<AbsenceData>()
             : await repository.GetByUrnsAsync(similarSchoolUrns);
+        var similarSchoolDataByUrn = similarSchoolData
+            .Where(x => !string.IsNullOrWhiteSpace(x.URN))
+            .ToDictionary(x => x.URN, StringComparer.Ordinal);
+        var similarSchoolDetails = similarSchoolUrns.Length == 0
+            ? Array.Empty<SAPSec.Core.Model.Generated.Establishment>()
+            : (await establishmentRepository.GetEstablishmentsAsync(similarSchoolUrns))
+                ?? Array.Empty<SAPSec.Core.Model.Generated.Establishment>();
+        var similarSchoolDetailsByUrn = similarSchoolDetails
+            .Where(x => !string.IsNullOrWhiteSpace(x.URN))
+            .ToDictionary(x => x.URN, StringComparer.Ordinal);
+        var similarSchoolMeasures = similarSchoolUrns
+            .Where(similarSchoolDetailsByUrn.ContainsKey)
+            .Select(urn => new SimilarSchoolAttendanceMeasure(
+                urn,
+                similarSchoolDetailsByUrn[urn].EstablishmentName,
+                similarSchoolDataByUrn.GetValueOrDefault(urn)))
+            .ToArray();
 
         var overallSchoolSeries = new AttendanceMeasureSeries(
             ParseNullableDecimal(data?.EstablishmentAbsence?.Abs_Tot_Est_Current_Pct),
@@ -71,6 +88,14 @@ public class GetAttendanceMeasures(
                     ParseNullableDecimal(x.EstablishmentAbsence?.Abs_Tot_Est_Previous2_Pct)))),
                 Average(overallLocalAuthoritySeries.Current, overallLocalAuthoritySeries.Previous, overallLocalAuthoritySeries.Previous2),
                 Average(overallEnglandSeries.Current, overallEnglandSeries.Previous, overallEnglandSeries.Previous2)),
+            BuildTopPerformers(
+                establishment,
+                Average(overallSchoolSeries.Current, overallSchoolSeries.Previous, overallSchoolSeries.Previous2),
+                similarSchoolMeasures,
+                x => Average(
+                    ParseNullableDecimal(x.AbsenceData?.EstablishmentAbsence?.Abs_Tot_Est_Current_Pct),
+                    ParseNullableDecimal(x.AbsenceData?.EstablishmentAbsence?.Abs_Tot_Est_Previous_Pct),
+                    ParseNullableDecimal(x.AbsenceData?.EstablishmentAbsence?.Abs_Tot_Est_Previous2_Pct))),
             new AttendanceMeasureYearByYear(
                 overallSchoolSeries,
                 overallSimilarSchoolsSeries,
@@ -84,6 +109,14 @@ public class GetAttendanceMeasures(
                     ParseNullableDecimal(x.EstablishmentAbsence?.Abs_Persistent_Est_Previous2_Pct)))),
                 Average(persistentLocalAuthoritySeries.Current, persistentLocalAuthoritySeries.Previous, persistentLocalAuthoritySeries.Previous2),
                 Average(persistentEnglandSeries.Current, persistentEnglandSeries.Previous, persistentEnglandSeries.Previous2)),
+            BuildTopPerformers(
+                establishment,
+                Average(persistentSchoolSeries.Current, persistentSchoolSeries.Previous, persistentSchoolSeries.Previous2),
+                similarSchoolMeasures,
+                x => Average(
+                    ParseNullableDecimal(x.AbsenceData?.EstablishmentAbsence?.Abs_Persistent_Est_Current_Pct),
+                    ParseNullableDecimal(x.AbsenceData?.EstablishmentAbsence?.Abs_Persistent_Est_Previous_Pct),
+                    ParseNullableDecimal(x.AbsenceData?.EstablishmentAbsence?.Abs_Persistent_Est_Previous2_Pct))),
             new AttendanceMeasureYearByYear(
                 persistentSchoolSeries,
                 persistentSimilarSchoolsSeries,
@@ -124,6 +157,38 @@ public class GetAttendanceMeasures(
             ? null
             : Math.Round(availableValues.Average(), 2, MidpointRounding.AwayFromZero);
     }
+
+    private static IReadOnlyList<AttendanceTopPerformer> BuildTopPerformers(
+        SAPSec.Core.Model.Generated.Establishment currentSchool,
+        decimal? currentSchoolValue,
+        IEnumerable<SimilarSchoolAttendanceMeasure> similarSchools,
+        Func<SimilarSchoolAttendanceMeasure, decimal?> selector)
+    {
+        var currentSchoolCandidate = new AttendanceTopPerformerCandidate(
+            currentSchool.URN,
+            currentSchool.EstablishmentName,
+            currentSchoolValue,
+            IsCurrentSchool: true);
+
+        return similarSchools
+            .Select(x => new AttendanceTopPerformerCandidate(x.Urn, x.Name, selector(x), IsCurrentSchool: false))
+            .Append(currentSchoolCandidate)
+            .Where(x => x.Value.HasValue)
+            .GroupBy(x => x.Urn, StringComparer.Ordinal)
+            .Select(x => x.OrderByDescending(candidate => candidate.IsCurrentSchool).First())
+            .OrderBy(x => x.Value)
+            .ThenBy(x => x.Name, StringComparer.OrdinalIgnoreCase)
+            .Take(3)
+            .Select((x, index) => new AttendanceTopPerformer(index + 1, x.Urn, x.Name, x.Value, x.IsCurrentSchool))
+            .ToList()
+            .AsReadOnly();
+    }
+
+    private sealed record AttendanceTopPerformerCandidate(
+        string Urn,
+        string Name,
+        decimal? Value,
+        bool IsCurrentSchool);
 }
 
 public record GetAttendanceMeasuresRequest(string Urn);
@@ -147,6 +212,20 @@ public record AttendanceMeasureYearByYear(
 
 public record GetAttendanceMeasuresResponse(
     AttendanceMeasureAverage OverallAbsenceThreeYearAverage,
+    IReadOnlyList<AttendanceTopPerformer> OverallAbsenceTopPerformers,
     AttendanceMeasureYearByYear OverallAbsenceYearByYear,
     AttendanceMeasureAverage PersistentAbsenceThreeYearAverage,
+    IReadOnlyList<AttendanceTopPerformer> PersistentAbsenceTopPerformers,
     AttendanceMeasureYearByYear PersistentAbsenceYearByYear);
+
+public record AttendanceTopPerformer(
+    int Rank,
+    string Urn,
+    string Name,
+    decimal? Value,
+    bool IsCurrentSchool = false);
+
+internal sealed record SimilarSchoolAttendanceMeasure(
+    string Urn,
+    string Name,
+    AbsenceData? AbsenceData);

--- a/SAPSec.Web/Controllers/SchoolController.cs
+++ b/SAPSec.Web/Controllers/SchoolController.cs
@@ -126,6 +126,9 @@ public class SchoolController : Controller
         var englandThreeYearAverage = isPersistentAbsence
             ? response.PersistentAbsenceThreeYearAverage.EnglandValue
             : response.OverallAbsenceThreeYearAverage.EnglandValue;
+        var topPerformers = isPersistentAbsence
+            ? response.PersistentAbsenceTopPerformers
+            : response.OverallAbsenceTopPerformers;
 
         return Json(new
         {
@@ -175,7 +178,15 @@ public class SchoolController : Controller
                     DisplayPercentNullable(englandSeries.Current),
                     DisplayPercentNullable(englandThreeYearAverage)
                 }
-            }
+            },
+            topPerformers = topPerformers.Select(x => new
+            {
+                x.Rank,
+                x.Urn,
+                x.Name,
+                x.IsCurrentSchool,
+                DisplayValue = SchoolAttendancePageViewModel.DisplayPercentNullable(x.Value)
+            })
         });
     }
 

--- a/SAPSec.Web/ViewModels/SchoolAttendancePageViewModel.cs
+++ b/SAPSec.Web/ViewModels/SchoolAttendancePageViewModel.cs
@@ -7,6 +7,8 @@ namespace SAPSec.Web.ViewModels;
 
 public class SchoolAttendancePageViewModel
 {
+    public record TopPerformerRow(int Rank, string Urn, string Name, decimal? Value, string DisplayValue, bool IsCurrentSchool);
+
     public required SchoolDetails SchoolDetails { get; init; }
     public required GetAttendanceMeasuresResponse AttendanceMeasures { get; init; }
 
@@ -26,6 +28,18 @@ public class SchoolAttendancePageViewModel
     public decimal? SimilarSchoolsPersistentAbsenceThreeYearAverage => AttendanceMeasures.PersistentAbsenceThreeYearAverage.SimilarSchoolsValue;
     public decimal? LocalAuthorityPersistentAbsenceThreeYearAverage => AttendanceMeasures.PersistentAbsenceThreeYearAverage.LocalAuthorityValue;
     public decimal? EnglandPersistentAbsenceThreeYearAverage => AttendanceMeasures.PersistentAbsenceThreeYearAverage.EnglandValue;
+
+    public IReadOnlyList<TopPerformerRow> OverallAbsenceTopPerformers =>
+        AttendanceMeasures.OverallAbsenceTopPerformers
+            .Select(x => new TopPerformerRow(x.Rank, x.Urn, x.Name, x.Value, DisplayPercentNullable(x.Value), x.IsCurrentSchool))
+            .ToList()
+            .AsReadOnly();
+
+    public IReadOnlyList<TopPerformerRow> PersistentAbsenceTopPerformers =>
+        AttendanceMeasures.PersistentAbsenceTopPerformers
+            .Select(x => new TopPerformerRow(x.Rank, x.Urn, x.Name, x.Value, DisplayPercentNullable(x.Value), x.IsCurrentSchool))
+            .ToList()
+            .AsReadOnly();
 
     public static string DisplayPercentNullable(decimal? value) =>
         value.HasValue

--- a/SAPSec.Web/Views/School/Attendance.cshtml
+++ b/SAPSec.Web/Views/School/Attendance.cshtml
@@ -176,7 +176,7 @@
         </div>
 
         <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="attendance-top-performers">
-            <p class="govuk-body">These are the top performing similar schools schools for this measure.</p>
+            <p class="govuk-body">These are the top performing similar schools for this measure.</p>
             <table class="govuk-table" id="attendance-top-performers-table">
                 <thead class="govuk-table__head">
                 <tr class="govuk-table__row">

--- a/SAPSec.Web/Views/School/Attendance.cshtml
+++ b/SAPSec.Web/Views/School/Attendance.cshtml
@@ -34,6 +34,8 @@
     var chartColors = new[] { "#D53780", "#2a1950", "#2a1950", "#2a1950" };
     var lineChartColors = new[] { "#D53780", "#2a1950", "#5694CA", "#28A197" };
     var attendanceDataEndpoint = Url.Action("AttendanceData", "School", new { urn = Model.SchoolDetails.Urn });
+    string SimilarSchoolsUrl() => Url.Action("ViewSimilarSchools", "SimilarSchools", new { urn = Model.SchoolDetails.Urn }) ?? $"/school/{Model.SchoolDetails.Urn}/view-similar-schools";
+    string SimilarSchoolComparisonUrl(string similarSchoolUrn) => Url.Action("Index", "SimilarSchoolsComparison", new { urn = Model.SchoolDetails.Urn, similarSchoolUrn }) ?? $"/school/{Model.SchoolDetails.Urn}/view-similar-schools/{similarSchoolUrn}";
 }
 
 <span class="govuk-caption-xl">@Model.SchoolName</span>
@@ -68,7 +70,9 @@
                     data-line-chart-id="school-attendance-year-by-year-chart"
                     data-cell-attribute="data-attendance-cell"
                     data-cell-prefixes='{"school":"school","similarSchools":"similar","localAuthority":"la","england":"england"}'
-                    data-series-keys='["school","similarSchools","localAuthority","england"]'>
+                    data-series-keys='["school","similarSchools","localAuthority","england"]'
+                    data-top-performers-table-id="attendance-top-performers-table"
+                    data-top-performer-base-url="/school/@Model.SchoolDetails.Urn/view-similar-schools">
                 <option value="overall" selected>Overall absence</option>
                 <option value="persistent">Persistent absence</option>
             </select>
@@ -86,6 +90,9 @@
             </li>
             <li class="govuk-tabs__list-item">
                 <a class="govuk-tabs__tab" href="#attendance-table">Table</a>
+            </li>
+            <li class="govuk-tabs__list-item">
+                <a class="govuk-tabs__tab" href="#attendance-top-performers">Top performers</a>
             </li>
         </ul>
 
@@ -166,6 +173,39 @@
                 </tr>
                 </tbody>
             </table>
+        </div>
+
+        <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="attendance-top-performers">
+            <p class="govuk-body">These are the top performing similar schools schools for this measure.</p>
+            <table class="govuk-table" id="attendance-top-performers-table">
+                <thead class="govuk-table__head">
+                <tr class="govuk-table__row">
+                    <th scope="col" class="govuk-table__header">Rank</th>
+                    <th scope="col" class="govuk-table__header">School</th>
+                    <th scope="col" class="govuk-table__header govuk-table__header--numeric">3-year average</th>
+                </tr>
+                </thead>
+                <tbody class="govuk-table__body">
+                @foreach (var row in Model.OverallAbsenceTopPerformers)
+                {
+                    <tr class="govuk-table__row">
+                        <td class="govuk-table__cell">@row.Rank</td>
+                        <th scope="row" class="govuk-table__header">
+                            @if (row.IsCurrentSchool)
+                            {
+                                @row.Name
+                            }
+                            else
+                            {
+                                <a href="@SimilarSchoolComparisonUrl(row.Urn)" class="govuk-link">@row.Name</a>
+                            }
+                        </th>
+                        <td class="govuk-table__cell govuk-table__cell--numeric">@row.DisplayValue</td>
+                    </tr>
+                }
+                </tbody>
+            </table>
+            <p class="govuk-body govuk-!-margin-bottom-1"><a href="@SimilarSchoolsUrl()" class="govuk-link">See all similar schools</a></p>
         </div>
     </div>
 </section>

--- a/Tests/SAPSec.Core.Tests/Features/Attendance/UseCases/GetAttendanceMeasuresTests.cs
+++ b/Tests/SAPSec.Core.Tests/Features/Attendance/UseCases/GetAttendanceMeasuresTests.cs
@@ -40,7 +40,7 @@ public class GetAttendanceMeasuresTests
 
         establishmentRepositoryMock
             .Setup(x => x.GetEstablishmentAsync("123456"))
-            .ReturnsAsync(new Establishment { URN = "123456", LAId = "373" });
+            .ReturnsAsync(new Establishment { URN = "123456", LAId = "373", EstablishmentName = "Current School" });
 
         repositoryMock
             .Setup(x => x.GetByUrnAsync("123456"))
@@ -111,18 +111,37 @@ public class GetAttendanceMeasuresTests
                     null,
                     null)
             ]);
+        establishmentRepositoryMock
+            .Setup(x => x.GetEstablishmentsAsync(It.Is<IEnumerable<string>>(urns => urns.SequenceEqual(new[] { "200001", "200002" }))))
+            .ReturnsAsync(
+            [
+                new Establishment { URN = "200001", EstablishmentName = "Beta School" },
+                new Establishment { URN = "200002", EstablishmentName = "Alpha School" }
+            ]);
 
         var sut = new GetAttendanceMeasures(repositoryMock.Object, establishmentRepositoryMock.Object, similarSchoolsRepositoryMock.Object);
 
         var result = await sut.Execute(new GetAttendanceMeasuresRequest("123456"));
 
         result.OverallAbsenceThreeYearAverage.Should().Be(new AttendanceMeasureAverage(5.2m, 5.7m, 4.83m, 4.9m));
+        result.OverallAbsenceTopPerformers.Should().BeEquivalentTo(
+        [
+            new AttendanceTopPerformer(1, "200002", "Alpha School", 5.2m),
+            new AttendanceTopPerformer(2, "123456", "Current School", 5.2m, true),
+            new AttendanceTopPerformer(3, "200001", "Beta School", 6.2m)
+        ], options => options.WithStrictOrdering());
         result.OverallAbsenceYearByYear.School.Should().Be(new AttendanceMeasureSeries(5.0m, 5.2m, 5.4m));
         result.OverallAbsenceYearByYear.SimilarSchools.Should().Be(new AttendanceMeasureSeries(5.5m, 5.7m, 5.9m));
         result.OverallAbsenceYearByYear.LocalAuthority.Should().Be(new AttendanceMeasureSeries(4.7m, 4.8m, 5.0m));
         result.OverallAbsenceYearByYear.England.Should().Be(new AttendanceMeasureSeries(4.8m, 4.9m, 5.0m));
 
         result.PersistentAbsenceThreeYearAverage.Should().Be(new AttendanceMeasureAverage(16.4m, 17.9m, 15.3m, 15.83m));
+        result.PersistentAbsenceTopPerformers.Should().BeEquivalentTo(
+        [
+            new AttendanceTopPerformer(1, "123456", "Current School", 16.4m, true),
+            new AttendanceTopPerformer(2, "200002", "Alpha School", 17.4m),
+            new AttendanceTopPerformer(3, "200001", "Beta School", 18.4m)
+        ], options => options.WithStrictOrdering());
         result.PersistentAbsenceYearByYear.School.Should().Be(new AttendanceMeasureSeries(16.0m, 16.4m, 16.8m));
         result.PersistentAbsenceYearByYear.SimilarSchools.Should().Be(new AttendanceMeasureSeries(17.5m, 17.9m, 18.3m));
         result.PersistentAbsenceYearByYear.LocalAuthority.Should().Be(new AttendanceMeasureSeries(15.1m, 15.3m, 15.5m));
@@ -152,11 +171,13 @@ public class GetAttendanceMeasuresTests
         var result = await sut.Execute(new GetAttendanceMeasuresRequest("123456"));
 
         result.OverallAbsenceThreeYearAverage.Should().Be(new AttendanceMeasureAverage(null, null, null, null));
+        result.OverallAbsenceTopPerformers.Should().BeEmpty();
         result.OverallAbsenceYearByYear.School.Should().Be(new AttendanceMeasureSeries(null, null, null));
         result.OverallAbsenceYearByYear.SimilarSchools.Should().Be(new AttendanceMeasureSeries(null, null, null));
         result.OverallAbsenceYearByYear.LocalAuthority.Should().Be(new AttendanceMeasureSeries(null, null, null));
         result.OverallAbsenceYearByYear.England.Should().Be(new AttendanceMeasureSeries(null, null, null));
         result.PersistentAbsenceThreeYearAverage.Should().Be(new AttendanceMeasureAverage(null, null, null, null));
+        result.PersistentAbsenceTopPerformers.Should().BeEmpty();
         result.PersistentAbsenceYearByYear.School.Should().Be(new AttendanceMeasureSeries(null, null, null));
         result.PersistentAbsenceYearByYear.SimilarSchools.Should().Be(new AttendanceMeasureSeries(null, null, null));
         result.PersistentAbsenceYearByYear.LocalAuthority.Should().Be(new AttendanceMeasureSeries(null, null, null));
@@ -214,7 +235,9 @@ public class GetAttendanceMeasuresTests
         var result = await sut.Execute(new GetAttendanceMeasuresRequest("123456"));
 
         result.OverallAbsenceThreeYearAverage.Should().Be(new AttendanceMeasureAverage(null, null, null, null));
+        result.OverallAbsenceTopPerformers.Should().BeEmpty();
         result.PersistentAbsenceThreeYearAverage.Should().Be(new AttendanceMeasureAverage(null, null, null, null));
+        result.PersistentAbsenceTopPerformers.Should().BeEmpty();
     }
 
 }

--- a/Tests/SAPSec.UI.Tests/SchoolAttendancePageTests.cs
+++ b/Tests/SAPSec.UI.Tests/SchoolAttendancePageTests.cs
@@ -131,7 +131,7 @@ public class SchoolAttendancePageTests(WebApplicationSetupFixture fixture) : Bas
         await Page.Locator(".app-attendance-tabs .govuk-tabs__tab[href='#attendance-top-performers']").ClickAsync();
 
         await Expect(Page.Locator("#attendance-top-performers")).ToContainTextAsync(
-            "These are the top performing similar schools schools for this measure.");
+            "These are the top performing similar schools for this measure.");
         await Expect(Page.Locator("#attendance-top-performers-table thead")).ToContainTextAsync("Rank");
         await Expect(Page.Locator("#attendance-top-performers-table thead")).ToContainTextAsync("School");
         await Expect(Page.Locator("#attendance-top-performers-table thead")).ToContainTextAsync("3-year average");

--- a/Tests/SAPSec.UI.Tests/SchoolAttendancePageTests.cs
+++ b/Tests/SAPSec.UI.Tests/SchoolAttendancePageTests.cs
@@ -42,6 +42,7 @@ public class SchoolAttendancePageTests(WebApplicationSetupFixture fixture) : Bas
         await Expect(Page.Locator("#school-attendance-three-year-chart")).ToHaveAttributeAsync("data-colors", "[\"#D53780\",\"#2a1950\",\"#2a1950\",\"#2a1950\"]");
         await Expect(Page.Locator(".app-attendance-tabs .govuk-tabs__tab[href='#attendance-year-by-year']")).ToBeVisibleAsync();
         await Expect(Page.Locator(".app-attendance-tabs .govuk-tabs__tab[href='#attendance-table']")).ToBeVisibleAsync();
+        await Expect(Page.Locator(".app-attendance-tabs .govuk-tabs__tab[href='#attendance-top-performers']")).ToBeVisibleAsync();
         await Expect(Page.Locator("label[for='attendanceAbsenceType']")).ToHaveClassAsync(new Regex("govuk-label--s"));
         await Expect(Page.Locator("#attendanceAbsenceType")).ToHaveValueAsync("overall");
     }
@@ -120,5 +121,37 @@ public class SchoolAttendancePageTests(WebApplicationSetupFixture fixture) : Bas
         await tableTab.ClickAsync();
         await Expect(Page.Locator("#attendance-table .govuk-table")).ToBeVisibleAsync();
         await Expect(Page.Locator("#attendance-table .govuk-table")).ToContainTextAsync("Similar schools average");
+    }
+
+    [Fact]
+    public async Task Attendance_TopPerformersTab_RendersExpectedContent_AndUpdatesForPersistentAbsence()
+    {
+        await NavigateToAttendanceAsync();
+
+        await Page.Locator(".app-attendance-tabs .govuk-tabs__tab[href='#attendance-top-performers']").ClickAsync();
+
+        await Expect(Page.Locator("#attendance-top-performers")).ToContainTextAsync(
+            "These are the top performing similar schools schools for this measure.");
+        await Expect(Page.Locator("#attendance-top-performers-table thead")).ToContainTextAsync("Rank");
+        await Expect(Page.Locator("#attendance-top-performers-table thead")).ToContainTextAsync("School");
+        await Expect(Page.Locator("#attendance-top-performers-table thead")).ToContainTextAsync("3-year average");
+        await Expect(Page.Locator("#attendance-top-performers-table tbody tr")).ToHaveCountAsync(3);
+        await Expect(Page.Locator("#attendance-top-performers-table tbody tr").Nth(0)).ToContainTextAsync("1");
+        await Expect(Page.GetByRole(AriaRole.Link, new() { Name = "See all similar schools" }))
+            .ToHaveAttributeAsync("href", "/school/145327/view-similar-schools");
+
+        var initialValues = await Page.Locator("#attendance-top-performers-table tbody [data-top-performer-value], #attendance-top-performers-table tbody .govuk-table__cell--numeric")
+            .AllTextContentsAsync();
+
+        await Page.SelectOptionAsync("#attendanceAbsenceType", "persistent");
+        await Expect(Page.Locator("#attendanceAbsenceType")).ToHaveValueAsync("persistent");
+        await Expect(Page.Locator("#attendance-top-performers-table tbody tr")).ToHaveCountAsync(3);
+
+        await Page.WaitForFunctionAsync(
+            @"([selector, initial]) => {
+                const values = Array.from(document.querySelectorAll(selector)).map(x => x.textContent.trim());
+                return JSON.stringify(values) !== initial;
+            }",
+            new object[] { "#attendance-top-performers-table tbody .govuk-table__cell--numeric", System.Text.Json.JsonSerializer.Serialize(initialValues) });
     }
 }

--- a/Tests/SAPSec.Web.Tests/Controllers/SchoolControllerTests.cs
+++ b/Tests/SAPSec.Web.Tests/Controllers/SchoolControllerTests.cs
@@ -263,7 +263,7 @@ public class SchoolControllerTests
 
         _establishmentRepositoryMock
             .Setup(x => x.GetEstablishmentAsync(urn))
-            .ReturnsAsync(new Establishment { URN = urn, LAId = "373" });
+            .ReturnsAsync(new Establishment { URN = urn, LAId = "373", EstablishmentName = "Test Academy" });
         _schoolDetailsServiceMock
             .Setup(x => x.GetByUrnAsync(urn))
             .ReturnsAsync(schoolDetails);
@@ -293,7 +293,7 @@ public class SchoolControllerTests
 
         _establishmentRepositoryMock
             .Setup(x => x.GetEstablishmentAsync(urn))
-            .ReturnsAsync(new Establishment { URN = urn, LAId = "373" });
+            .ReturnsAsync(new Establishment { URN = urn, LAId = "373", EstablishmentName = "Test Academy" });
         _absenceRepositoryMock
             .Setup(x => x.GetByUrnAsync(urn))
             .ReturnsAsync(new AbsenceData(
@@ -363,6 +363,13 @@ public class SchoolControllerTests
                     null,
                     null)
             ]);
+        _establishmentRepositoryMock
+            .Setup(x => x.GetEstablishmentsAsync(It.Is<IEnumerable<string>>(urns => urns.SequenceEqual(new[] { "200001", "200002" }))))
+            .ReturnsAsync(
+            [
+                new Establishment { URN = "200001", EstablishmentName = "Beta School" },
+                new Establishment { URN = "200002", EstablishmentName = "Alpha School" }
+            ]);
 
         var result = await _sut.AttendanceData(urn, "overall");
 
@@ -374,6 +381,8 @@ public class SchoolControllerTests
         root.GetProperty("bar").GetArrayLength().Should().Be(4);
         root.GetProperty("line").GetProperty("similarSchools").GetArrayLength().Should().Be(3);
         root.GetProperty("table").GetProperty("similarSchools").GetArrayLength().Should().Be(4);
+        root.GetProperty("topPerformers").GetArrayLength().Should().Be(3);
+        root.GetProperty("topPerformers")[0].GetProperty("Name").GetString().Should().Be("Test Academy");
     }
 
     #endregion


### PR DESCRIPTION
## Description

Adds a new Top performers tab to the Attendance page.
It shows the top 3 similar schools for:

- Overall absence
- Persistent absence

The table updates when the attendance filter changes. It also includes links to compare schools and a link to view all similar schools.
No new dependencies were added.

## Related Trello Ticket

https://trello.com/c/FrgJUF5I

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested locally and unit tests.

## Checklist

- [x ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x ] I have added tests that prove my fix is effective or that my feature works
- [x ] New and existing unit tests pass locally with my changes
- [x ] I have verified accessibility requirements are met


## Screenshots (if applicable)

<img width="878" height="643" alt="image" src="https://github.com/user-attachments/assets/44e4f818-4e73-4c35-925e-fe6c2372d40a" />