### PR TITLE
Attainment 8 description tweak

### DIFF
--- a/SAPSec.Web/Views/Shared/_Ks4Attainment8Intro.cshtml
+++ b/SAPSec.Web/Views/Shared/_Ks4Attainment8Intro.cshtml
@@ -19,7 +19,7 @@
                 </ul>
             </li>
             <li>EBacc subjects, which include sciences, geography, history, and languages</li>
-            <li>Open group subjects, which can include GCSEs or vocational qualifications (including any other approved GCSEs or vocational qualifications)</li>
+            <li>Open group subjects, which can include any other approved GCSEs or vocational qualifications</li>
         </ul>
         <p class="govuk-body-s govuk-!-margin-bottom-2">
             Each GCSE grade is given a points score, for example grade 9 = 9 points, grade 8 = 8 points, and so on. The score from the best 8 subjects (with English and maths counting twice) are added together to give an Attainment 8 score.


### PR DESCRIPTION


## Description

Sarah Stewart noticed that the current Attainment 8 description includes the sentence:

Open group subjects, which can include GCSEs or vocational qualifications (including any other approved GCSEs or vocational qualifications)

I have suggested this changes to:

Open group subjects, which can include any other approved GCSEs or vocational qualifications

Signed off by Penny Crouzet and Bob Tarrant 

## Related Trello Ticket

https://trello.com/c/ZWrswwcS

## Type of change

Please delete options that are not relevant.

- [y ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Unit tests added/updated 
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] Tested on [Environment: Dev/Staging/Local]

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have verified accessibility requirements are met


## Screenshots (if applicable)

Add UI changes, logs, console outputs anything to help reviewers.