### PR TITLE
Fix issues with remembering element state when changing KS2 measure filters

### DIFF
--- a/SAPSec.Web/AssetSrc/js/content-toggle.js
+++ b/SAPSec.Web/AssetSrc/js/content-toggle.js
@@ -26,7 +26,7 @@ function resizeCharts(container) {
     });
 }
 
-function initialiseToggle(toggle) {
+function initialiseToggle(toggle, activeIndex) {
     var title = toggle.querySelector(".app-content-toggle__title");
     var button = toggle.querySelector(".app-content-toggle__header button[type='button']");
     var panels = Array.prototype.slice.call(toggle.querySelectorAll("[data-content-toggle-panel]"));
@@ -35,9 +35,11 @@ function initialiseToggle(toggle) {
         return;
     }
 
-    var activeIndex = panels.findIndex(function (panel) {
-        return !panel.hasAttribute("hidden");
-    });
+    if (!activeIndex) {
+        activeIndex = panels.findIndex(function (panel) {
+            return !panel.hasAttribute("hidden");
+        });
+    }
 
     if (activeIndex < 0) {
         activeIndex = 0;
@@ -70,8 +72,21 @@ function initialiseToggle(toggle) {
     render(activeIndex);
 }
 
-function init(element) {
-    element.querySelectorAll('.app-content-toggle').forEach(initialiseToggle);
+function getActiveIndex(element) {
+    var panels = Array.prototype.slice.call(element.querySelectorAll(".app-content-toggle [data-content-toggle-panel]"));
+    var activeIndex = panels.findIndex(function (panel) {
+        return !panel.hasAttribute("hidden");
+    });
+
+    if (activeIndex < 0) {
+        activeIndex = 0;
+    }
+
+    return activeIndex;
+}
+
+function init(element, activeIndex) {
+    element.querySelectorAll('.app-content-toggle').forEach(t => initialiseToggle(t, activeIndex));
 }
 
 function initAll() {
@@ -85,5 +100,6 @@ function initAll() {
 
 export {
     init,
-    initAll
+    initAll,
+    getActiveIndex
 };

--- a/SAPSec.Web/AssetSrc/js/measure-filters.js
+++ b/SAPSec.Web/AssetSrc/js/measure-filters.js
@@ -47,16 +47,28 @@ function init(select) {
                     return;
                 }
 
-                const responseContent = new DOMParser().parseFromString(content, "text/html");
-                const measureFromResponse = responseContent.getElementById(targetId);
-                const target = document.getElementById(targetId);
-                const selectedTab = target.querySelector('a[aria-selected="true"]')?.getAttribute('href');
-                target.innerHTML = measureFromResponse.innerHTML;
+                const targetElement = document.getElementById(targetId);
 
-                ChartFactory.init(target);
-                ContentToggle.init(target);
-                const tabs = new MobileCollapsedTabs(target.querySelector('[data-module="govuk-tabs"]'));
-                tabs.selectTabById(selectedTab);
+                // Get current state of tab panels
+                const tabs = window.GOVUKComponents['MobileCollapsedTabs'];
+                const i = tabs.findIndex(t => t.$root == targetElement.querySelector('[data-module="govuk-tabs"]'));
+                var tabState = tabs[i].getState();
+
+                // Get current state of content toggle
+                var toggleActiveIndex = ContentToggle.getActiveIndex(targetElement);
+
+                // Replace target element with same element from response
+                const responseContent = new DOMParser().parseFromString(content, "text/html");
+                const targetElementFromResponse = responseContent.getElementById(targetId);
+                targetElement.innerHTML = targetElementFromResponse.innerHTML;
+
+                // Re-initialise components, with saved state
+                tabs[i].teardown();
+                tabs[i] = new MobileCollapsedTabs(targetElement.querySelector('[data-module="govuk-tabs"]'));
+                tabs[i].setState(tabState);
+
+                ChartFactory.init(targetElement);
+                ContentToggle.init(targetElement, toggleActiveIndex);
             })
             .catch(function (error) {
                 console.error("Failed to load view data.", error);

--- a/SAPSec.Web/AssetSrc/js/mobile-collapsed-tabs.js
+++ b/SAPSec.Web/AssetSrc/js/mobile-collapsed-tabs.js
@@ -3,15 +3,56 @@
 class MobileCollapsedTabs extends Tabs {
     constructor(t) {
         super(t);
+
+        this.scrollLefts = {};
+        this.boundTabPanelScrollEnd = this.onTabPanelScrollEnd.bind(this);
+        this.$tabs.forEach((t => {
+            const tabPanel = this.getPanel(t);
+            tabPanel.addEventListener("scrollend", this.boundTabPanelScrollEnd, !0);
+        }))
+    }
+    teardown() {
+        super.teardown();
+
+        this.$tabs.forEach((t => {
+            const tabPanel = this.getPanel(t);
+            tabPanel.removeEventListener("scrollend", this.boundTabPanelScrollEnd, !0);
+        }))
     }
     setupResponsiveChecks() {
         this.mql = window.matchMedia(`(min-width: 0)`), "addEventListener" in this.mql ? this.mql.addEventListener("change", (() => this.checkMode())) : this.mql.addListener((() => this.checkMode())), this.checkMode()
     }
-    selectTabById(tabId) {
-        if (tabId) {
+    onTabPanelScrollEnd(e) {
+        this.scrollLefts[e.target.id] = e.target.scrollLeft;
+    }
+    showPanel(t) {
+        super.showPanel(t);
+
+        const tabPanel = this.getPanel(t);
+        const scrollLeft = this.scrollLefts && this.scrollLefts[tabPanel.id];
+        tabPanel && scrollLeft && (tabPanel.scrollLeft = scrollLeft);
+    }
+    getState() {
+        const currentTab = this.getCurrentTab();
+
+        return {
+            currentTabId: currentTab.hash,
+            scrollLefts: this.scrollLefts
+        };
+    }
+    setState(state) {
+        if (state.currentTabId) {
             const currentTab = this.getCurrentTab();
-            const selectedTab = this.getTab(tabId);
-            currentTab && selectedTab && (this.hideTab(currentTab), this.showTab(selectedTab), selectedTab.focus())
+            const selectedTab = this.getTab(state.currentTabId);
+            currentTab && selectedTab && (this.hideTab(currentTab), this.showTab(selectedTab))
+        }
+
+        if (state.scrollLefts) {
+            this.scrollLefts = state.scrollLefts;
+            this.$tabs.forEach((t => {
+                const tabPanel = this.getPanel(t);
+                tabPanel.scrollLeft = this.scrollLefts[tabPanel.id];
+            }))
         }
     }
 }

--- a/SAPSec.Web/Views/Shared/_Layout.cshtml
+++ b/SAPSec.Web/Views/Shared/_Layout.cshtml
@@ -243,6 +243,8 @@ n&&j.setAttribute('nonce',n.nonce||n.getAttribute('nonce'));f.parentNode.insertB
 
         // Override GOVUKFrontend initAll() to replace Tabs component with MobileCollapsedTabs
         function initAll() {
+            window.GOVUKComponents = {};
+
             [
                 GOVUKFrontend.Accordion,
                 GOVUKFrontend.Button,
@@ -259,7 +261,8 @@ n&&j.setAttribute('nonce',n.nonce||n.getAttribute('nonce'));f.parentNode.insertB
                 GOVUKFrontend.SkipLink,
                 MobileCollapsedTabs // Replace Tabs component with MobileCollapsedTabs
             ].forEach(Component => {
-                GOVUKFrontend.createAll(Component, {} , {})
+                // Store component objects on window so component can be accessed to get/set state
+                window.GOVUKComponents[Component.name] = GOVUKFrontend.createAll(Component, {}, {}); 
             })
         }
 

--- a/SAPSec.Web/gulpfile.cjs
+++ b/SAPSec.Web/gulpfile.cjs
@@ -175,6 +175,10 @@ const copyStaticAssets = () =>
                 .pipe(gulp.dest("wwwroot/css/"))
         );
 
+const watchStaticAssets = () =>
+    gulp
+        .watch(["AssetSrc/js/*"], copyStaticAssets);
+
 gulp.task("build-fe", () => {
     return async.series([
         (next) => buildSass().on("end", next),
@@ -183,7 +187,8 @@ gulp.task("build-fe", () => {
 });
 
 gulp.task("watch-fe", () => {
-    return async.series([
-        (next) => watchSass().on("end", next)
+    return async.parallel([
+        (next) => watchSass().on("end", next),
+        (next) => watchStaticAssets().on("end", next)
     ]);
 });


### PR DESCRIPTION
## Description

Fixes issues raised in the below ticket:
* When viewing the year by year chart, updating the filter selection resets the view back to the bar chart view rather. Looking at secondary schools, the view remains on the year by year chart when updating the filters - please can the behaviour be the same for primary schools.
* When on top performers or table view on mobile, then updating the filter resets the view of the table (e.g. if user has scrolled across on the table then updating filter resets the view back to the start of the table). For secondary schools, the view remains the same when switching between filters - please can it be the same for secondary.
* Use tab/arrow keys to update filter - when I update the filter using the arrow key then it automatically moves focus to the tabs below. The focus should remain on the subject filter as per secondary school behaviour.

**Note:** This is implemented by getting relevant state from the existing components (e.g. tab panels and content toggle) in the target element, before the target element is replaced by content from the filter response. Then when components are re-initialised, the previous state is passed to them. Previous implementation of measure filters for secondary schools did not have this problem as rather than replacing the HTML of the target element completely, it retrieved the new data for the components and replaced all the values keeping the existing component bindings active.

## Related Trello Ticket

https://trello.com/c/1oFrkYyL/921-ps24-meeting-expected-standard-in-reading-writing-and-maths-subject-filters

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Unit tests added/updated 
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [x] Tested on Local

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have verified accessibility requirements are met