### PR TITLE
Add KS2 Acheived a higher standard in RWM measure and filters

### DIFF
--- a/SAPSec.Core/Constants/Measures.cs
+++ b/SAPSec.Core/Constants/Measures.cs
@@ -7,6 +7,7 @@ public static class Measures
         public static class Ks2ExpectedRwm
         {
             public const string Key = "expected-rwm";
+            public const string Name = "Meeting expected standard in reading, writing and maths";
 
             public static class Filters
             {
@@ -33,10 +34,60 @@ public static class Measures
             }
         }
 
-        public const string Ks2GpsExpected = "expected-gps";
-        public const string Ks2GpsHigher = "higher-gps";
-        public const string Ks2ReadingScore = "reading-score";
-        public const string Ks2MathsScore = "maths-score";
+        public static class Ks2HigherRwm
+        {
+            public const string Key = "higher-rwm";
+            public const string Name = "Achieved a higher standard in reading, writing and maths";
+
+            public static class Filters
+            {
+                public static class Subject
+                {
+                    public const string Key = $"{Ks2HigherRwm.Key}-subject";
+                    public const string Name = "Subject";
+
+                    public static class Values
+                    {
+                        public const string ReadingWritingMaths = "rwm";
+                        public const string Reading = "r";
+                        public const string Writing = "w";
+                        public const string Maths = "m";
+
+                        public static readonly FilterValueDefinition[] AllValues = [
+                            new(ReadingWritingMaths, "Reading, writing and maths"),
+                            new(Reading, "Reading"),
+                            new(Writing, "Writing"),
+                            new(Maths, "Maths"),
+                        ];
+                    }
+                }
+            }
+        }
+
+        public static class Ks2ReadingScore
+        {
+            public const string Key = "reading-score";
+            public const string Name = "Average scaled score in reading";
+        }
+
+        public static class Ks2MathsScore
+        {
+            public const string Key = "maths-score";
+            public const string Name = "Average scaled score in maths";
+        }
+
+        public static class Ks2ExpectedGps
+        {
+            public const string Key = "expected-gps";
+            public const string Name = "Meeting expected standard in grammar, punctuation and spelling";
+        }
+
+        public static class Ks2HigherGps
+        {
+            public const string Key = "higher-gps";
+            public const string Name = "Achieved a higher standard in grammar, punctuation and spelling";
+        }
+
     }
 
     public record FilterValueDefinition(string Value, string Name);

--- a/SAPSec.Core/Features/Measures/Measure.cs
+++ b/SAPSec.Core/Features/Measures/Measure.cs
@@ -5,6 +5,7 @@ namespace SAPSec.Core.Features.Measures;
 
 public record Measure(
     string Key,
+    string Name,
     MeasureDataType DataType,
     IReadOnlyCollection<MeasureAvailableFilter> Filters,
     IReadOnlyCollection<MeasureSeries> Series,
@@ -12,6 +13,7 @@ public record Measure(
 {
     internal static Measure ForSchool<T>(
         string key,
+        string name,
         MeasureDataType dataType,
         IEnumerable<MeasureAvailableFilter> availableFilters,
         SchoolData<T> currentSchool,
@@ -20,6 +22,7 @@ public record Measure(
     {
         return new Measure(
             key,
+            name,
             dataType,
             availableFilters.ToList(),
             MeasureSeries.ForSchool(currentSchool, similarSchools, fieldSelector),
@@ -28,6 +31,7 @@ public record Measure(
 
     internal static Measure ForSchoolComparison<T>(
         string key,
+        string name,
         MeasureDataType dataType,
         IEnumerable<MeasureAvailableFilter> availableFilters,
         SchoolData<T> currentSchool,
@@ -37,6 +41,7 @@ public record Measure(
     {
         return new Measure(
             key,
+            name,
             dataType,
             availableFilters.ToList(),
             MeasureSeries.ForSchoolComparison(currentSchool, similarSchool, fieldSelector));

--- a/SAPSec.Core/Features/Primary/GetSchoolKs2PerformanceMeasuresUseCase.cs
+++ b/SAPSec.Core/Features/Primary/GetSchoolKs2PerformanceMeasuresUseCase.cs
@@ -30,7 +30,7 @@ public class GetSchoolKs2PerformanceMeasuresUseCase(
                 similarSchoolsPerformance,
                 filterBy
             ),
-            Ks2PerformanceMeasures.MeetingExpectedStandardGps.ForSchool(
+            Ks2PerformanceMeasures.AchievedHigherStandardRwm.ForSchool(
                 currentSchoolPerformance,
                 similarSchoolsPerformance,
                 filterBy
@@ -41,6 +41,11 @@ public class GetSchoolKs2PerformanceMeasuresUseCase(
                 filterBy
             ),
             Ks2PerformanceMeasures.AverageScaledScoreMaths.ForSchool(
+                currentSchoolPerformance,
+                similarSchoolsPerformance,
+                filterBy
+            ),
+            Ks2PerformanceMeasures.MeetingExpectedStandardGps.ForSchool(
                 currentSchoolPerformance,
                 similarSchoolsPerformance,
                 filterBy
@@ -62,7 +67,8 @@ public record GetSchoolKs2PerformanceMeasuresResponse(
     SchoolInfo.SchoolInfo School,
     int SimilarSchoolsCount,
     Measure MeetingExpectedStandardRwm,
-    Measure MeetingExpectedStandardGps,
+    Measure AchievedHigherStandardRwm,
     Measure AverageScaledScoreReading,
     Measure AverageScaledScoreMaths,
+    Measure MeetingExpectedStandardGps,
     Measure AchievedHigherStandardGps);

--- a/SAPSec.Core/Features/Primary/Ks2PerformanceMeasures.cs
+++ b/SAPSec.Core/Features/Primary/Ks2PerformanceMeasures.cs
@@ -18,6 +18,7 @@ internal static class Ks2PerformanceMeasures
 
             return Measure.ForSchool(
                 Ks2ExpectedRwm.Key,
+                Ks2ExpectedRwm.Name,
                 MeasureDataType.GradePercentage,
                 availableFilters,
                 currentSchool,
@@ -31,6 +32,7 @@ internal static class Ks2PerformanceMeasures
 
             return Measure.ForSchoolComparison(
                 Ks2ExpectedRwm.Key,
+                Ks2ExpectedRwm.Name,
                 MeasureDataType.GradePercentage,
                 availableFilters,
                 currentSchool,
@@ -102,47 +104,97 @@ internal static class Ks2PerformanceMeasures
         }
     }
 
-    public static class MeetingExpectedStandardGps
+    public static class AchievedHigherStandardRwm
     {
         public static Measure ForSchool(SchoolData<Ks2PerformanceData> currentSchool, IEnumerable<SchoolData<Ks2PerformanceData>> similarSchools, CaseInsensitiveDictionary<string> filters)
         {
+            var (availableFilters, fieldSelector) = ResolveFilters(filters);
+
             return Measure.ForSchool(
-                Ks2GpsExpected,
+                Ks2HigherRwm.Key,
+                Ks2HigherRwm.Name,
                 MeasureDataType.GradePercentage,
-                [],
+                availableFilters,
                 currentSchool,
                 similarSchools,
-                new MeasureFieldSelector<Ks2PerformanceData>(
-                    x => x?.EstablishmentPerformance?.GpsExpected_Tot_Cohort_Est_Current_Num,
-                    x => x?.EstablishmentPerformance?.GpsExpected_Tot_Cohort_Est_Previous_Num,
-                    x => x?.EstablishmentPerformance?.GpsExpected_Tot_Cohort_Est_Previous2_Num,
-                    x => x?.LocalAuthorityPerformance?.GpsExpected_Tot_Cohort_LA_Current_Num,
-                    x => x?.LocalAuthorityPerformance?.GpsExpected_Tot_Cohort_LA_Previous_Num,
-                    x => x?.LocalAuthorityPerformance?.GpsExpected_Tot_Cohort_LA_Previous2_Num,
-                    x => x?.EnglandPerformance?.GpsExpected_Tot_Cohort_Eng_Current_Num,
-                    x => x?.EnglandPerformance?.GpsExpected_Tot_Cohort_Eng_Previous_Num,
-                    x => x?.EnglandPerformance?.GpsExpected_Tot_Cohort_Eng_Previous2_Num));
+                fieldSelector);
         }
 
         public static Measure ForSchoolComparison(SchoolData<Ks2PerformanceData> currentSchool, SchoolData<Ks2PerformanceData> similarSchool, IEnumerable<SchoolData<Ks2PerformanceData>> similarSchools, CaseInsensitiveDictionary<string> filters)
         {
+            var (availableFilters, fieldSelector) = ResolveFilters(filters);
+
             return Measure.ForSchoolComparison(
-                Ks2GpsExpected,
+                Ks2HigherRwm.Key,
+                Ks2HigherRwm.Name,
                 MeasureDataType.GradePercentage,
-                [],
+                availableFilters,
                 currentSchool,
                 similarSchool,
                 similarSchools,
-                new MeasureFieldSelector<Ks2PerformanceData>(
-                    x => x?.EstablishmentPerformance?.GpsExpected_Tot_Cohort_Est_Current_Num,
-                    x => x?.EstablishmentPerformance?.GpsExpected_Tot_Cohort_Est_Previous_Num,
-                    x => x?.EstablishmentPerformance?.GpsExpected_Tot_Cohort_Est_Previous2_Num,
-                    x => x?.LocalAuthorityPerformance?.GpsExpected_Tot_Cohort_LA_Current_Num,
-                    x => x?.LocalAuthorityPerformance?.GpsExpected_Tot_Cohort_LA_Previous_Num,
-                    x => x?.LocalAuthorityPerformance?.GpsExpected_Tot_Cohort_LA_Previous2_Num,
-                    x => x?.EnglandPerformance?.GpsExpected_Tot_Cohort_Eng_Current_Num,
-                    x => x?.EnglandPerformance?.GpsExpected_Tot_Cohort_Eng_Previous_Num,
-                    x => x?.EnglandPerformance?.GpsExpected_Tot_Cohort_Eng_Previous2_Num));
+                fieldSelector);
+        }
+
+        private static (IEnumerable<MeasureAvailableFilter> AvailableFilters, MeasureFieldSelector<Ks2PerformanceData> FieldSelector) ResolveFilters(CaseInsensitiveDictionary<string> filters)
+        {
+            var subject = filters.ContainsKey(Ks2HigherRwm.Filters.Subject.Key)
+                ? filters[Ks2HigherRwm.Filters.Subject.Key]
+                : Ks2HigherRwm.Filters.Subject.Values.ReadingWritingMaths;
+
+            IEnumerable<MeasureAvailableFilter> availableFilters = [
+                new MeasureAvailableFilter(
+                    Ks2HigherRwm.Filters.Subject.Key,
+                    Ks2HigherRwm.Filters.Subject.Name,
+                    Ks2HigherRwm.Filters.Subject.Values.AllValues.Select(f =>
+                        new FilterOption(f.Value, f.Name, f.Value.EqualsCaseInsensitive(subject)))
+                    .ToList())
+            ];
+
+            MeasureFieldSelector<Ks2PerformanceData> fieldSelector = subject switch
+            {
+                _ when subject.EqualsCaseInsensitive(Ks2HigherRwm.Filters.Subject.Values.Reading) => new(
+                    x => x?.EstablishmentPerformance?.RwmHigher_Reading_Tot_Cohort_Est_Current_Num,
+                    x => x?.EstablishmentPerformance?.RwmHigher_Reading_Tot_Cohort_Est_Previous_Num,
+                    x => x?.EstablishmentPerformance?.RwmHigher_Reading_Tot_Cohort_Est_Previous2_Num,
+                    x => x?.LocalAuthorityPerformance?.RwmHigher_Reading_Tot_Cohort_LA_Current_Num,
+                    x => x?.LocalAuthorityPerformance?.RwmHigher_Reading_Tot_Cohort_LA_Previous_Num,
+                    x => x?.LocalAuthorityPerformance?.RwmHigher_Reading_Tot_Cohort_LA_Previous2_Num,
+                    x => x?.EnglandPerformance?.RwmHigher_Reading_Tot_Cohort_Eng_Current_Num,
+                    x => x?.EnglandPerformance?.RwmHigher_Reading_Tot_Cohort_Eng_Previous_Num,
+                    x => x?.EnglandPerformance?.RwmHigher_Reading_Tot_Cohort_Eng_Previous2_Num),
+                _ when subject.EqualsCaseInsensitive(Ks2HigherRwm.Filters.Subject.Values.Writing) => new(
+                    x => x?.EstablishmentPerformance?.RwmHigher_Writing_Tot_Cohort_Est_Current_Num,
+                    x => x?.EstablishmentPerformance?.RwmHigher_Writing_Tot_Cohort_Est_Previous_Num,
+                    x => x?.EstablishmentPerformance?.RwmHigher_Writing_Tot_Cohort_Est_Previous2_Num,
+                    x => x?.LocalAuthorityPerformance?.RwmHigher_Writing_Tot_Cohort_LA_Current_Num,
+                    x => x?.LocalAuthorityPerformance?.RwmHigher_Writing_Tot_Cohort_LA_Previous_Num,
+                    x => x?.LocalAuthorityPerformance?.RwmHigher_Writing_Tot_Cohort_LA_Previous2_Num,
+                    x => x?.EnglandPerformance?.RwmHigher_Writing_Tot_Cohort_Eng_Current_Num,
+                    x => x?.EnglandPerformance?.RwmHigher_Writing_Tot_Cohort_Eng_Previous_Num,
+                    x => x?.EnglandPerformance?.RwmHigher_Writing_Tot_Cohort_Eng_Previous2_Num),
+                _ when subject.EqualsCaseInsensitive(Ks2HigherRwm.Filters.Subject.Values.Maths) => new(
+                    x => x?.EstablishmentPerformance?.RwmHigher_Maths_Tot_Cohort_Est_Current_Num,
+                    x => x?.EstablishmentPerformance?.RwmHigher_Maths_Tot_Cohort_Est_Previous_Num,
+                    x => x?.EstablishmentPerformance?.RwmHigher_Maths_Tot_Cohort_Est_Previous2_Num,
+                    x => x?.LocalAuthorityPerformance?.RwmHigher_Maths_Tot_Cohort_LA_Current_Num,
+                    x => x?.LocalAuthorityPerformance?.RwmHigher_Maths_Tot_Cohort_LA_Previous_Num,
+                    x => x?.LocalAuthorityPerformance?.RwmHigher_Maths_Tot_Cohort_LA_Previous2_Num,
+                    x => x?.EnglandPerformance?.RwmHigher_Maths_Tot_Cohort_Eng_Current_Num,
+                    x => x?.EnglandPerformance?.RwmHigher_Maths_Tot_Cohort_Eng_Previous_Num,
+                    x => x?.EnglandPerformance?.RwmHigher_Maths_Tot_Cohort_Eng_Previous2_Num),
+                _ => new(
+                    x => x?.EstablishmentPerformance?.RwmHigher_Tot_Cohort_Est_Current_Num,
+                    x => x?.EstablishmentPerformance?.RwmHigher_Tot_Cohort_Est_Previous_Num,
+                    x => x?.EstablishmentPerformance?.RwmHigher_Tot_Cohort_Est_Previous2_Num,
+                    x => x?.LocalAuthorityPerformance?.RwmHigher_Tot_Cohort_LA_Current_Num,
+                    x => x?.LocalAuthorityPerformance?.RwmHigher_Tot_Cohort_LA_Previous_Num,
+                    x => x?.LocalAuthorityPerformance?.RwmHigher_Tot_Cohort_LA_Previous2_Num,
+                    x => x?.EnglandPerformance?.RwmHigher_Tot_Cohort_Eng_Current_Num,
+                    x => x?.EnglandPerformance?.RwmHigher_Tot_Cohort_Eng_Previous_Num,
+                    x => x?.EnglandPerformance?.RwmHigher_Tot_Cohort_Eng_Previous2_Num)
+            };
+
+            return (availableFilters, fieldSelector);
         }
     }
 
@@ -151,7 +203,8 @@ internal static class Ks2PerformanceMeasures
         public static Measure ForSchool(SchoolData<Ks2PerformanceData> currentSchool, IEnumerable<SchoolData<Ks2PerformanceData>> similarSchools, CaseInsensitiveDictionary<string> filters)
         {
             return Measure.ForSchool(
-                Ks2ReadingScore,
+                Ks2ReadingScore.Key,
+                Ks2ReadingScore.Name,
                 MeasureDataType.ScaledScore,
                 [],
                 currentSchool,
@@ -171,7 +224,8 @@ internal static class Ks2PerformanceMeasures
         public static Measure ForSchoolComparison(SchoolData<Ks2PerformanceData> currentSchool, SchoolData<Ks2PerformanceData> similarSchool, IEnumerable<SchoolData<Ks2PerformanceData>> similarSchools, CaseInsensitiveDictionary<string> filters)
         {
             return Measure.ForSchoolComparison(
-                Ks2ReadingScore,
+                Ks2ReadingScore.Key,
+                Ks2ReadingScore.Name,
                 MeasureDataType.ScaledScore,
                 [],
                 currentSchool,
@@ -195,7 +249,8 @@ internal static class Ks2PerformanceMeasures
         public static Measure ForSchool(SchoolData<Ks2PerformanceData> currentSchool, IEnumerable<SchoolData<Ks2PerformanceData>> similarSchools, CaseInsensitiveDictionary<string> filters)
         {
             return Measure.ForSchool(
-                Ks2MathsScore,
+                Ks2MathsScore.Key,
+                Ks2MathsScore.Name,
                 MeasureDataType.ScaledScore,
                 [],
                 currentSchool,
@@ -215,7 +270,8 @@ internal static class Ks2PerformanceMeasures
         public static Measure ForSchoolComparison(SchoolData<Ks2PerformanceData> currentSchool, SchoolData<Ks2PerformanceData> similarSchool, IEnumerable<SchoolData<Ks2PerformanceData>> similarSchools, CaseInsensitiveDictionary<string> filters)
         {
             return Measure.ForSchoolComparison(
-                Ks2MathsScore,
+                Ks2MathsScore.Key,
+                Ks2MathsScore.Name,
                 MeasureDataType.ScaledScore,
                 [],
                 currentSchool,
@@ -234,12 +290,59 @@ internal static class Ks2PerformanceMeasures
         }
     }
 
+    public static class MeetingExpectedStandardGps
+    {
+        public static Measure ForSchool(SchoolData<Ks2PerformanceData> currentSchool, IEnumerable<SchoolData<Ks2PerformanceData>> similarSchools, CaseInsensitiveDictionary<string> filters)
+        {
+            return Measure.ForSchool(
+                Ks2ExpectedGps.Key,
+                Ks2ExpectedGps.Name,
+                MeasureDataType.GradePercentage,
+                [],
+                currentSchool,
+                similarSchools,
+                new MeasureFieldSelector<Ks2PerformanceData>(
+                    x => x?.EstablishmentPerformance?.GpsExpected_Tot_Cohort_Est_Current_Num,
+                    x => x?.EstablishmentPerformance?.GpsExpected_Tot_Cohort_Est_Previous_Num,
+                    x => x?.EstablishmentPerformance?.GpsExpected_Tot_Cohort_Est_Previous2_Num,
+                    x => x?.LocalAuthorityPerformance?.GpsExpected_Tot_Cohort_LA_Current_Num,
+                    x => x?.LocalAuthorityPerformance?.GpsExpected_Tot_Cohort_LA_Previous_Num,
+                    x => x?.LocalAuthorityPerformance?.GpsExpected_Tot_Cohort_LA_Previous2_Num,
+                    x => x?.EnglandPerformance?.GpsExpected_Tot_Cohort_Eng_Current_Num,
+                    x => x?.EnglandPerformance?.GpsExpected_Tot_Cohort_Eng_Previous_Num,
+                    x => x?.EnglandPerformance?.GpsExpected_Tot_Cohort_Eng_Previous2_Num));
+        }
+
+        public static Measure ForSchoolComparison(SchoolData<Ks2PerformanceData> currentSchool, SchoolData<Ks2PerformanceData> similarSchool, IEnumerable<SchoolData<Ks2PerformanceData>> similarSchools, CaseInsensitiveDictionary<string> filters)
+        {
+            return Measure.ForSchoolComparison(
+                Ks2ExpectedGps.Key,
+                Ks2ExpectedGps.Name,
+                MeasureDataType.GradePercentage,
+                [],
+                currentSchool,
+                similarSchool,
+                similarSchools,
+                new MeasureFieldSelector<Ks2PerformanceData>(
+                    x => x?.EstablishmentPerformance?.GpsExpected_Tot_Cohort_Est_Current_Num,
+                    x => x?.EstablishmentPerformance?.GpsExpected_Tot_Cohort_Est_Previous_Num,
+                    x => x?.EstablishmentPerformance?.GpsExpected_Tot_Cohort_Est_Previous2_Num,
+                    x => x?.LocalAuthorityPerformance?.GpsExpected_Tot_Cohort_LA_Current_Num,
+                    x => x?.LocalAuthorityPerformance?.GpsExpected_Tot_Cohort_LA_Previous_Num,
+                    x => x?.LocalAuthorityPerformance?.GpsExpected_Tot_Cohort_LA_Previous2_Num,
+                    x => x?.EnglandPerformance?.GpsExpected_Tot_Cohort_Eng_Current_Num,
+                    x => x?.EnglandPerformance?.GpsExpected_Tot_Cohort_Eng_Previous_Num,
+                    x => x?.EnglandPerformance?.GpsExpected_Tot_Cohort_Eng_Previous2_Num));
+        }
+    }
+
     public static class AchievedHigherStandardGps
     {
         public static Measure ForSchool(SchoolData<Ks2PerformanceData> currentSchool, IEnumerable<SchoolData<Ks2PerformanceData>> similarSchools, CaseInsensitiveDictionary<string> filters)
         {
             return Measure.ForSchool(
-                Ks2GpsHigher,
+                Ks2HigherGps.Key,
+                Ks2HigherGps.Name,
                 MeasureDataType.GradePercentage,
                 [],
                 currentSchool,
@@ -259,7 +362,8 @@ internal static class Ks2PerformanceMeasures
         public static Measure ForSchoolComparison(SchoolData<Ks2PerformanceData> currentSchool, SchoolData<Ks2PerformanceData> similarSchool, IEnumerable<SchoolData<Ks2PerformanceData>> similarSchools, CaseInsensitiveDictionary<string> filters)
         {
             return Measure.ForSchoolComparison(
-                Ks2GpsHigher,
+                Ks2HigherGps.Key,
+                Ks2HigherGps.Name,
                 MeasureDataType.GradePercentage,
                 [],
                 currentSchool,

--- a/SAPSec.Web/Areas/Primary/Controllers/SchoolController.cs
+++ b/SAPSec.Web/Areas/Primary/Controllers/SchoolController.cs
@@ -53,6 +53,7 @@ public class SchoolController(
         {
             School = SchoolInfoViewModel.FromSchoolInfo(response.School),
             MeetingExpectedStandardRwm = MeasureViewModel.FromMeasure(response.MeetingExpectedStandardRwm, response.School),
+            AchievedHigherStandardRwm = MeasureViewModel.FromMeasure(response.AchievedHigherStandardRwm, response.School),
             AverageScaledScoreReading = MeasureViewModel.FromMeasure(response.AverageScaledScoreReading, response.School),
             AverageScaledScoreMaths = MeasureViewModel.FromMeasure(response.AverageScaledScoreMaths, response.School),
             MeetingExpectedStandardGps = MeasureViewModel.FromMeasure(response.MeetingExpectedStandardGps, response.School),

--- a/SAPSec.Web/Areas/Primary/ViewModels/Ks2MeasuresPageViewModel.cs
+++ b/SAPSec.Web/Areas/Primary/ViewModels/Ks2MeasuresPageViewModel.cs
@@ -8,8 +8,9 @@ public class Ks2MeasuresPageViewModel
     public required SchoolInfoViewModel School { get; set; }
 
     public required MeasureViewModel MeetingExpectedStandardRwm { get; set; }
-    public required MeasureViewModel MeetingExpectedStandardGps { get; set; }
+    public required MeasureViewModel AchievedHigherStandardRwm { get; set; }
     public required MeasureViewModel AverageScaledScoreReading { get; set; }
     public required MeasureViewModel AverageScaledScoreMaths { get; set; }
+    public required MeasureViewModel MeetingExpectedStandardGps { get; set; }
     public required MeasureViewModel AchievedHigherStandardGps { get; set; }
 }

--- a/SAPSec.Web/Areas/Primary/Views/School/Ks2PerformanceMeasures.cshtml
+++ b/SAPSec.Web/Areas/Primary/Views/School/Ks2PerformanceMeasures.cshtml
@@ -29,7 +29,7 @@
         <partial name="_Ks2ProgressRWMInfo" />
 
         <section class="app-measure-section" aria-labelledby="expected-rwm-heading">
-            <h2 class="govuk-heading-m" id="expected-rwm-heading" data-testid="expected-rwm-heading">Meeting expected standard in reading, writing and maths</h2>
+            <h2 class="govuk-heading-m" id="expected-rwm-heading" data-testid="expected-rwm-heading">@Model.MeetingExpectedStandardRwm.MeasureInfo.Name</h2>
 
             <details class="govuk-details app-measure-details" data-module="govuk-details">
                 <summary class="govuk-details__summary">
@@ -47,8 +47,26 @@
             <partial name="Measures/_Measure" model=@Model.MeetingExpectedStandardRwm />
         </section>
 
+        <section class="app-measure-section" aria-labelledby="higher-rwm-heading">
+            <h2 class="govuk-heading-m" id="higher-rwm-heading" data-testid="higher-rwm-heading">@Model.AchievedHigherStandardRwm.MeasureInfo.Name</h2>
+
+            <details class="govuk-details app-measure-details" data-module="govuk-details">
+                <summary class="govuk-details__summary">
+                    <span class="govuk-details__summary-text">Information about achieving the higher standard</span>
+                </summary>
+                <div class="govuk-details__text">
+                    <p class="govuk-body-s govuk-!-margin-bottom-2">
+                        Pupils achieve the higher standard when they achieve a scaled score of 110 or more
+                        in reading and maths tests, and are assessed by their teacher in writing as &lsquo;working at greater depth&rsquo;.
+                    </p>
+                </div>
+            </details>
+            
+            <partial name="Measures/_Measure" model=@Model.AchievedHigherStandardRwm />
+        </section>
+
         <section class="app-measure-section" aria-labelledby="reading-score-heading">
-            <h2 class="govuk-heading-m" id="reading-score-heading" data-testid="reading-score-heading">Average scaled score in reading</h2>
+            <h2 class="govuk-heading-m" id="reading-score-heading" data-testid="reading-score-heading">@Model.AverageScaledScoreReading.MeasureInfo.Name</h2>
 
             <details class="govuk-details app-measure-details" data-module="govuk-details">
                 <summary class="govuk-details__summary">
@@ -66,7 +84,7 @@
         </section>
         
         <section class="app-measure-section" aria-labelledby="maths-score-heading">
-            <h2 class="govuk-heading-m" id="maths-score-heading" data-testid="maths-score-heading">Average scaled score in maths</h2>
+            <h2 class="govuk-heading-m" id="maths-score-heading" data-testid="maths-score-heading">@Model.AverageScaledScoreMaths.MeasureInfo.Name</h2>
 
             <details class="govuk-details app-measure-details" data-module="govuk-details">
                 <summary class="govuk-details__summary">
@@ -84,7 +102,7 @@
         </section>
 
         <section class="app-measure-section" aria-labelledby="expected-gps-heading">
-            <h2 class="govuk-heading-m" id="expected-gps-heading" data-testid="expected-gps-heading">Meeting expected standard in grammar, punctuation and spelling</h2>
+            <h2 class="govuk-heading-m" id="expected-gps-heading" data-testid="expected-gps-heading">@Model.MeetingExpectedStandardGps.MeasureInfo.Name</h2>
 
             <details class="govuk-details app-measure-details" data-module="govuk-details">
                 <summary class="govuk-details__summary">
@@ -102,7 +120,7 @@
         </section>
 
         <section class="app-measure-section" aria-labelledby="higher-gps-heading">
-            <h2 class="govuk-heading-m" id="higher-gps-heading" data-testid="higher-gps-heading">Achieved a higher standard in grammar, punctuation and spelling</h2>
+            <h2 class="govuk-heading-m" id="higher-gps-heading" data-testid="higher-gps-heading">@Model.AchievedHigherStandardGps.MeasureInfo.Name</h2>
 
             <details class="govuk-details app-measure-details" data-module="govuk-details">
                 <summary class="govuk-details__summary">

--- a/SAPSec.Web/ViewModels/Measures/MeasureViewModel.cs
+++ b/SAPSec.Web/ViewModels/Measures/MeasureViewModel.cs
@@ -1,7 +1,6 @@
 using SAPSec.Core.Features.Measures;
 using SAPSec.Core.Features.SchoolInfo;
 using SAPSec.Web.Constants;
-using static SAPSec.Core.Constants.Measures.Primary;
 
 namespace SAPSec.Web.ViewModels.Measures;
 
@@ -24,22 +23,6 @@ public record MeasureViewModel(
             _ => throw new InvalidOperationException($"No label found for Measure Series Type: {Enum.GetName(seriesType)}")
         };
 
-    private static string ResolveMeasureLabel(string measureKey) =>
-        measureKey switch
-        {
-            Ks2ExpectedRwm.Key =>
-                "Meeting expected standard in reading, writing and maths",
-            Ks2GpsExpected =>
-                "Meeting expected standard in grammar, punctuation and spelling",
-            Ks2GpsHigher =>
-                "Achieved a higher standard in grammar, punctuation and spelling",
-            Ks2ReadingScore =>
-                "Average scaled score in reading",
-            Ks2MathsScore =>
-                "Average scaled score in maths",
-            _ => throw new InvalidOperationException($"No label found for Measure Key: {measureKey}")
-        };
-
     public static MeasureViewModel FromMeasure(
         Measure measure,
         SchoolInfo schoolInfo,
@@ -47,7 +30,7 @@ public record MeasureViewModel(
     {
         var measureInfo = new MeasureInfoViewModel(
             measure.Key,
-            ResolveMeasureLabel(measure.Key),
+            measure.Name,
             measure.DataType,
             measure.Filters.Select(MapAvailableFilter),
             measure.Series.Select(s => ResolveSeriesLabel(s.SeriesType, schoolInfo, similarSchool)),

--- a/Tests/SAPSec.Core.Tests/Features/Primary/GetSchoolKs2PerformanceMeasuresUseCaseTests.cs
+++ b/Tests/SAPSec.Core.Tests/Features/Primary/GetSchoolKs2PerformanceMeasuresUseCaseTests.cs
@@ -54,6 +54,48 @@ public class GetSchoolKs2PerformanceMeasuresUseCaseTests
     }
 
     [Fact]
+    public async Task FilterBy_IgnoresInvalidFilterKeys()
+    {
+        _establishmentRepo.SetupEstablishments(
+            Build.Establishment("100001", "Test School 1", x => x.Primary()),
+            Build.Establishment("100002", "Test School 2", x => x.Primary()),
+            Build.Establishment("100003", "Test School 3", x => x.Primary()),
+            Build.Establishment("100004", "Test School 4", x => x.Primary()),
+            Build.Establishment("100005", "Test School 5", x => x.Primary()));
+
+        _similarSchoolsRepo.SetupGroups(
+            Build.PrimaryGroup("100001", ["100002", "100003", "100004", "100005"]));
+
+        _performanceRepo.SetupEstablishmentPerformance(
+            Build.Ks2Performance.Establishment("100001", x => x
+                .WithRwmExpected(current: "18", prev: "75", prev2: "80")
+                .WithRwmHigher(current: "18", prev: "75", prev2: "80")),
+            Build.Ks2Performance.Establishment("100002", x => x
+                .WithRwmExpected(current: "20", prev: "70", prev2: "50")
+                .WithRwmHigher(current: "20", prev: "70", prev2: "50")),
+            Build.Ks2Performance.Establishment("100003", x => x
+                .WithRwmExpected(current: "21", prev: "69", prev2: "51")
+                .WithRwmHigher(current: "21", prev: "69", prev2: "51")),
+            Build.Ks2Performance.Establishment("100004", x => x
+                .WithRwmExpected(current: "22", prev: "68", prev2: "49")
+                .WithRwmHigher(current: "22", prev: "68", prev2: "49")),
+            Build.Ks2Performance.Establishment("100005", x => x
+                .WithRwmExpected(current: "19", prev: "61", prev2: "67")
+                .WithRwmHigher(current: "19", prev: "61", prev2: "67")));
+
+        var response = await _sut.Execute(Request("100001", filterBy: new()
+        {
+            ["xxx"] = "1",
+            [Ks2ExpectedRwm.Filters.Subject.Key] = Ks2ExpectedRwm.Filters.Subject.Values.Maths,
+            [Ks2HigherRwm.Filters.Subject.Key] = Ks2HigherRwm.Filters.Subject.Values.Maths,
+            ["yyy"] = "2",
+        }));
+
+        response.MeetingExpectedStandardRwm.Series.Should().NotBeEmpty();
+        response.AchievedHigherStandardRwm.Series.Should().NotBeEmpty();
+    }
+
+    [Fact]
     public async Task MeetingExpectedStandardRwm_ShouldContainExpectedMeasureSeries()
     {
         _establishmentRepo.SetupEstablishments(
@@ -421,35 +463,7 @@ public class GetSchoolKs2PerformanceMeasuresUseCaseTests
         ]);
     }
 
-    [Fact]
-    public async Task FilterBy_IgnoresInvalidFilterKeys()
-    {
-        _establishmentRepo.SetupEstablishments(
-            Build.Establishment("100001", "Test School 1", x => x.Primary()),
-            Build.Establishment("100002", "Test School 2", x => x.Primary()),
-            Build.Establishment("100003", "Test School 3", x => x.Primary()),
-            Build.Establishment("100004", "Test School 4", x => x.Primary()),
-            Build.Establishment("100005", "Test School 5", x => x.Primary()));
 
-        _similarSchoolsRepo.SetupGroups(
-            Build.PrimaryGroup("100001", ["100002", "100003", "100004", "100005"]));
-
-        _performanceRepo.SetupEstablishmentPerformance(
-            Build.Ks2Performance.Establishment("100001", x => x.WithRwmExpected(current: "18", prev: "75", prev2: "80")),
-            Build.Ks2Performance.Establishment("100002", x => x.WithRwmExpected(current: "20", prev: "70", prev2: "50")),
-            Build.Ks2Performance.Establishment("100003", x => x.WithRwmExpected(current: "21", prev: "69", prev2: "51")),
-            Build.Ks2Performance.Establishment("100004", x => x.WithRwmExpected(current: "22", prev: "68", prev2: "49")),
-            Build.Ks2Performance.Establishment("100005", x => x.WithRwmExpected(current: "19", prev: "61", prev2: "67")));
-
-        var response = await _sut.Execute(Request("100001", filterBy: new()
-        {
-            ["xxx"] = "1",
-            [Ks2ExpectedRwm.Filters.Subject.Key] = Ks2ExpectedRwm.Filters.Subject.Values.Maths,
-            ["yyy"] = "2",
-        }));
-
-        response.MeetingExpectedStandardRwm.Series.Should().NotBeEmpty();
-    }
 
     [InlineData(Ks2ExpectedRwm.Filters.Subject.Values.Reading)]
     [InlineData(Ks2ExpectedRwm.Filters.Subject.Values.Writing)]
@@ -615,6 +629,543 @@ public class GetSchoolKs2PerformanceMeasuresUseCaseTests
         }));
 
         var topPerformers = response.MeetingExpectedStandardRwm.TopPerformers;
+
+        topPerformers.Should().NotBeNullOrEmpty();
+        topPerformers.Select(tp => tp.Urn).Should().Equal(expected);
+    }
+
+    [Fact]
+    public async Task AchievedHigherStandardRwm_ShouldContainExpectedMeasureSeries()
+    {
+        _establishmentRepo.SetupEstablishments(
+            Build.Establishment("100001", "Test School", x => x.Primary()));
+
+        var response = await _sut.Execute(Request("100001"));
+
+        response.School.Name.Should().Be("Test School");
+        var seriesTypes = response.AchievedHigherStandardRwm.Series.Select(s => s.SeriesType);
+
+        seriesTypes.Should().BeEquivalentTo([
+            MeasureSeriesType.CurrentSchool,
+            MeasureSeriesType.SimilarSchoolsAverage,
+            MeasureSeriesType.LASchoolsAverage,
+            MeasureSeriesType.EnglandSchoolsAverage
+        ]);
+    }
+
+    [InlineData(MeasureSeriesType.CurrentSchool)]
+    [InlineData(MeasureSeriesType.SimilarSchoolsAverage)]
+    [InlineData(MeasureSeriesType.LASchoolsAverage)]
+    [InlineData(MeasureSeriesType.EnglandSchoolsAverage)]
+    [Theory]
+    public async Task AchievedHigherStandardRwm_WhenNoPerformanceData_ContainsNullValues(MeasureSeriesType seriesType)
+    {
+        _establishmentRepo.SetupEstablishments(
+            Build.Establishment("100001", "Test School 1", x => x.Primary()),
+            Build.Establishment("100002", "Test School 2", x => x.Primary()),
+            Build.Establishment("100003", "Test School 3", x => x.Primary()));
+
+        _similarSchoolsRepo.SetupGroups(
+            Build.PrimaryGroup("100001", ["100002", "100003"]));
+
+        var response = await _sut.Execute(Request("100001"));
+
+        var series = response.AchievedHigherStandardRwm.Series
+            .FirstOrDefault(s => s.SeriesType == seriesType);
+
+        series.Should().NotBeNull();
+        series.Should().Be(
+            new MeasureSeries(seriesType, null, null, null));
+    }
+
+    [InlineData(MeasureSeriesType.CurrentSchool)]
+    [InlineData(MeasureSeriesType.SimilarSchoolsAverage)]
+    [InlineData(MeasureSeriesType.LASchoolsAverage)]
+    [InlineData(MeasureSeriesType.EnglandSchoolsAverage)]
+    [Theory]
+    public async Task AchievedHigherStandardRwm_WhenEmptyValues_ContainsNulls(MeasureSeriesType seriesType)
+    {
+        _establishmentRepo.SetupEstablishments(
+            Build.Establishment("100001", "Test School 1", x => x.Primary().InLA("001")),
+            Build.Establishment("100002", "Test School 2", x => x.Primary().InLA("001")),
+            Build.Establishment("100003", "Test School 3", x => x.Primary().InLA("001")),
+            Build.Establishment("100004", "Test School 4", x => x.Primary().InLA("001")));
+
+        _similarSchoolsRepo.SetupGroups(
+            Build.PrimaryGroup("100001", ["100002", "100003", "100004"]));
+
+        _performanceRepo.SetupEstablishmentPerformance(
+            Build.Ks2Performance.Establishment("100002", x => x.WithRwmHigher(current: "", prev: "", prev2: "")),
+            Build.Ks2Performance.Establishment("100003", x => x.WithRwmHigher(current: "", prev: "", prev2: "")),
+            Build.Ks2Performance.Establishment("100004", x => x.WithRwmHigher(current: "", prev: "", prev2: "")));
+
+        _performanceRepo.SetupLAPerformance(
+            Build.Ks2Performance.LA("001", x => x.WithRwmHigher(current: "", prev: "", prev2: "")));
+
+        _performanceRepo.SetupEnglandPerformance(
+            Build.Ks2Performance.England(x => x.WithRwmHigher(current: "", prev: "", prev2: "")));
+
+        var response = await _sut.Execute(Request("100001"));
+
+        var series = response.AchievedHigherStandardRwm.Series
+            .FirstOrDefault(s => s.SeriesType == seriesType);
+
+        series.Should().NotBeNull();
+        series.Should().Be(
+            new MeasureSeries(seriesType, null, null, null));
+    }
+
+    [InlineData(MeasureSeriesType.CurrentSchool)]
+    [InlineData(MeasureSeriesType.SimilarSchoolsAverage)]
+    [InlineData(MeasureSeriesType.LASchoolsAverage)]
+    [InlineData(MeasureSeriesType.EnglandSchoolsAverage)]
+    [Theory]
+    public async Task AchievedHigherStandardRwm_WhenInvalidValues_ContainsNulls(MeasureSeriesType seriesType)
+    {
+        _establishmentRepo.SetupEstablishments(
+            Build.Establishment("100001", "Test School 1", x => x.Primary().InLA("001")),
+            Build.Establishment("100002", "Test School 2", x => x.Primary().InLA("001")),
+            Build.Establishment("100003", "Test School 3", x => x.Primary().InLA("001")),
+            Build.Establishment("100004", "Test School 4", x => x.Primary().InLA("001")));
+
+        _similarSchoolsRepo.SetupGroups(
+            Build.PrimaryGroup("100001", ["100002", "100003", "100004"]));
+
+        _performanceRepo.SetupEstablishmentPerformance(
+            Build.Ks2Performance.Establishment("100002", x => x.WithRwmHigher(current: "x", prev: "y2", prev2: "3z")),
+            Build.Ks2Performance.Establishment("100003", x => x.WithRwmHigher(current: "x", prev: "y2", prev2: "3z")),
+            Build.Ks2Performance.Establishment("100004", x => x.WithRwmHigher(current: "x", prev: "y2", prev2: "3z")));
+
+        _performanceRepo.SetupLAPerformance(
+            Build.Ks2Performance.LA("001", x => x.WithRwmHigher(current: "x", prev: "y2", prev2: "3z")));
+
+        _performanceRepo.SetupEnglandPerformance(
+            Build.Ks2Performance.England(x => x.WithRwmHigher(current: "x", prev: "y2", prev2: "3z")));
+
+        var response = await _sut.Execute(Request("100001"));
+
+        var series = response.AchievedHigherStandardRwm.Series
+            .FirstOrDefault(s => s.SeriesType == seriesType);
+
+        series.Should().NotBeNull();
+        series.Should().Be(
+            new MeasureSeries(seriesType, null, null, null));
+    }
+
+    [InlineData(MeasureSeriesType.CurrentSchool, 81.0, 80.0, 79.0)]
+    [InlineData(MeasureSeriesType.SimilarSchoolsAverage, 70.0, 65.0, 82.5)]
+    [InlineData(MeasureSeriesType.LASchoolsAverage, 71.0, 70.0, 69.0)]
+    [InlineData(MeasureSeriesType.EnglandSchoolsAverage, 61.0, 60.0, 59.0)]
+    [Theory]
+    public async Task AchievedHigherStandardRwm_ContainsYearByYearValues(MeasureSeriesType seriesType, double? current, double? prev, double? prev2)
+    {
+        _establishmentRepo.SetupEstablishments(
+            Build.Establishment("100001", "Test School 1", x => x.Primary().InLA("001")),
+            Build.Establishment("100002", "Test School 2", x => x.Primary().InLA("001")),
+            Build.Establishment("100003", "Test School 3", x => x.Primary().InLA("001")));
+
+        _similarSchoolsRepo.SetupGroups(
+            Build.PrimaryGroup("100001", ["100002", "100003"]));
+
+        _performanceRepo.SetupEstablishmentPerformance(
+            Build.Ks2Performance.Establishment("100001", x => x.WithRwmHigher(current: "81", prev: "80", prev2: "79")),
+            Build.Ks2Performance.Establishment("100002", x => x.WithRwmHigher(current: "80", prev: "70", prev2: "85")),
+            Build.Ks2Performance.Establishment("100003", x => x.WithRwmHigher(current: "60", prev: "60", prev2: "80")));
+
+        _performanceRepo.SetupLAPerformance(
+            Build.Ks2Performance.LA("001", x => x.WithRwmHigher(current: "71", prev: "70", prev2: "69")));
+
+        _performanceRepo.SetupEnglandPerformance(
+            Build.Ks2Performance.England(x => x.WithRwmHigher(current: "61", prev: "60", prev2: "59")));
+
+        var response = await _sut.Execute(Request("100001"));
+
+        var series = response.AchievedHigherStandardRwm.Series
+            .FirstOrDefault(s => s.SeriesType == seriesType);
+
+        series.Should().NotBeNull();
+        series.Should().Be(
+            new MeasureSeries(seriesType, (decimal?)current, (decimal?)prev, (decimal?)prev2));
+    }
+
+    [Fact]
+    public async Task AchievedHigherStandardRwm_SimilarSchoolsAverage_WhenNoSimilarSchoolsForCurrentSchool_ContainsNullValues()
+    {
+        _establishmentRepo.SetupEstablishments(
+            Build.Establishment("100001", "Test School", x => x.Primary()));
+
+        var response = await _sut.Execute(Request("100001"));
+
+        var series = response.AchievedHigherStandardRwm.Series
+            .FirstOrDefault(s => s.SeriesType == MeasureSeriesType.SimilarSchoolsAverage);
+
+        series.Should().NotBeNull();
+        series.Should().Be(
+            new MeasureSeries(MeasureSeriesType.SimilarSchoolsAverage, null, null, null));
+    }
+
+    [Fact]
+    public async Task AchievedHigherStandardRwm_SimilarSchoolsAverage_WhenEmptyValuesPresent_CalculatesAverageOfRemainingValues()
+    {
+        _establishmentRepo.SetupEstablishments(
+            Build.Establishment("100001", "Test School 1", x => x.Primary()),
+            Build.Establishment("100002", "Test School 2", x => x.Primary()),
+            Build.Establishment("100003", "Test School 3", x => x.Primary()),
+            Build.Establishment("100004", "Test School 4", x => x.Primary()));
+
+        _similarSchoolsRepo.SetupGroups(
+            Build.PrimaryGroup("100001", ["100002", "100003", "100004"]));
+
+        _performanceRepo.SetupEstablishmentPerformance(
+            Build.Ks2Performance.Establishment("100002", x => x.WithRwmHigher(current: "", prev: "70", prev2: "")),
+            Build.Ks2Performance.Establishment("100003", x => x.WithRwmHigher(current: "80", prev: "", prev2: "")),
+            Build.Ks2Performance.Establishment("100004", x => x.WithRwmHigher(current: "60", prev: "60", prev2: "")));
+
+        var response = await _sut.Execute(Request("100001"));
+        var series = response.AchievedHigherStandardRwm.Series
+            .FirstOrDefault(s => s.SeriesType == MeasureSeriesType.SimilarSchoolsAverage);
+
+        series.Should().NotBeNull();
+        series.Should().Be(
+            new MeasureSeries(MeasureSeriesType.SimilarSchoolsAverage, 70, 65, null));
+    }
+
+    [InlineData("100001")]
+    [InlineData("100002")]
+    [InlineData("100003")]
+    [Theory]
+    public async Task AchievedHigherStandardRwm_LASchoolsAverage_WhenLAIdMissingOrInvalid_ContainsNullValues(string urn)
+    {
+        _establishmentRepo.SetupEstablishments(
+            Build.Establishment("100001", "Test School 1", x => x.Primary()),
+            Build.Establishment("100002", "Test School 2", x => x.Primary().InLA("002")),
+            Build.Establishment("100003", "Test School 3", x => x.Primary().InLA("XYZ")));
+
+        _performanceRepo.SetupLAPerformance(
+            Build.Ks2Performance.LA("001", x => x.WithRwmHigher(current: "71", prev: "70", prev2: "69")));
+
+        var response = await _sut.Execute(Request(urn));
+
+        var series = response.AchievedHigherStandardRwm.Series
+            .FirstOrDefault(s => s.SeriesType == MeasureSeriesType.LASchoolsAverage);
+
+        series.Should().NotBeNull();
+        series.Should().Be(
+            new MeasureSeries(MeasureSeriesType.LASchoolsAverage, null, null, null));
+    }
+
+    [Fact]
+    public async Task AchievedHigherStandardRwm_TopPerfomers_WhenNoPerformanceDataForSimilarSchools_IsEmpty()
+    {
+        _establishmentRepo.SetupEstablishments(
+            Build.Establishment("100001", "Test School 1", x => x.Primary()),
+            Build.Establishment("100002", "Test School 2", x => x.Primary()),
+            Build.Establishment("100003", "Test School 3", x => x.Primary()));
+
+        _similarSchoolsRepo.SetupGroups(
+            Build.PrimaryGroup("100001", ["100002", "100003"]));
+
+        var response = await _sut.Execute(Request("100001"));
+        var topPerformers = response.AchievedHigherStandardRwm.TopPerformers;
+
+        topPerformers.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task AchievedHigherStandardRwm_TopPerfomers_WhenNoPerformanceDataForSchool_SchoolDoesNotAppear()
+    {
+        _establishmentRepo.SetupEstablishments(
+            Build.Establishment("100001", "Test School 1", x => x.Primary()),
+            Build.Establishment("100002", "Test School 2", x => x.Primary()),
+            Build.Establishment("100003", "Test School 3", x => x.Primary()));
+
+        _similarSchoolsRepo.SetupGroups(
+            Build.PrimaryGroup("100001", ["100002", "100003"]));
+
+        _performanceRepo.SetupEstablishmentPerformance(
+            Build.Ks2Performance.Establishment("100001", x => x.WithRwmHigher(current: "20", prev: "70", prev2: "50")),
+            Build.Ks2Performance.Establishment("100003", x => x.WithRwmHigher(current: "22", prev: "68", prev2: "49")));
+
+        var response = await _sut.Execute(Request("100001"));
+        var topPerformers = response.AchievedHigherStandardRwm.TopPerformers;
+
+        topPerformers.Should().BeEquivalentTo([
+            new TopPerformer(1, "100003", "Test School 3", 22, IsCurrentSchool: false),
+            new TopPerformer(2, "100001", "Test School 1", 20, IsCurrentSchool: true)
+        ]);
+    }
+
+    [Fact]
+    public async Task AchievedHigherStandardRwm_TopPerfomers_WhenNoPerformanceDataForSchoolForCurrentYear_SchoolDoesNotAppear()
+    {
+        _establishmentRepo.SetupEstablishments(
+            Build.Establishment("100001", "Test School 1", x => x.Primary()),
+            Build.Establishment("100002", "Test School 2", x => x.Primary()),
+            Build.Establishment("100003", "Test School 3", x => x.Primary()));
+
+        _similarSchoolsRepo.SetupGroups(
+            Build.PrimaryGroup("100001", ["100002", "100003"]));
+
+        _performanceRepo.SetupEstablishmentPerformance(
+            Build.Ks2Performance.Establishment("100001", x => x.WithRwmHigher(current: "20", prev: "70", prev2: "50")),
+            Build.Ks2Performance.Establishment("100002", x => x.WithRwmHigher(current: "", prev: "69", prev2: "51")),
+            Build.Ks2Performance.Establishment("100003", x => x.WithRwmHigher(current: "22", prev: "68", prev2: "49")));
+
+        var response = await _sut.Execute(Request("100001"));
+        var topPerformers = response.AchievedHigherStandardRwm.TopPerformers;
+
+        topPerformers.Should().BeEquivalentTo([
+            new TopPerformer(1, "100003", "Test School 3", 22, IsCurrentSchool: false),
+            new TopPerformer(2, "100001", "Test School 1", 20, IsCurrentSchool: true)
+        ]);
+    }
+
+    [Fact]
+    public async Task AchievedHigherStandardRwm_TopPerfomers_RanksSimilarSchoolsBasedOnCurrentYearValue()
+    {
+        _establishmentRepo.SetupEstablishments(
+            Build.Establishment("100001", "Test School 1", x => x.Primary()),
+            Build.Establishment("100002", "Test School 2", x => x.Primary()),
+            Build.Establishment("100003", "Test School 3", x => x.Primary()));
+
+        _similarSchoolsRepo.SetupGroups(
+            Build.PrimaryGroup("100001", ["100002", "100003"]));
+
+        _performanceRepo.SetupEstablishmentPerformance(
+            Build.Ks2Performance.Establishment("100001", x => x.WithRwmHigher(current: "20", prev: "70", prev2: "50")),
+            Build.Ks2Performance.Establishment("100002", x => x.WithRwmHigher(current: "21", prev: "69", prev2: "51")),
+            Build.Ks2Performance.Establishment("100003", x => x.WithRwmHigher(current: "22", prev: "68", prev2: "49")));
+
+        var response = await _sut.Execute(Request("100001"));
+        var topPerformers = response.AchievedHigherStandardRwm.TopPerformers;
+
+        topPerformers.Should().BeEquivalentTo([
+            new TopPerformer(1, "100003", "Test School 3", 22, IsCurrentSchool: false),
+            new TopPerformer(2, "100002", "Test School 2", 21, IsCurrentSchool: false),
+            new TopPerformer(3, "100001", "Test School 1", 20, IsCurrentSchool: true)
+        ]);
+    }
+
+    [Fact]
+    public async Task AchievedHigherStandardRwm_TopPerfomers_RanksSimilarSchoolsBasedOnNameIfSameCurrentYearValue()
+    {
+        _establishmentRepo.SetupEstablishments(
+            Build.Establishment("100001", "Test School CCC", x => x.Primary()),
+            Build.Establishment("100002", "Test School AAA", x => x.Primary()),
+            Build.Establishment("100003", "Test School BBB", x => x.Primary()));
+
+        _similarSchoolsRepo.SetupGroups(
+            Build.PrimaryGroup("100001", ["100002", "100003"]));
+
+        _performanceRepo.SetupEstablishmentPerformance(
+            Build.Ks2Performance.Establishment("100001", x => x.WithRwmHigher(current: "20", prev: "70", prev2: "50")),
+            Build.Ks2Performance.Establishment("100002", x => x.WithRwmHigher(current: "20", prev: "69", prev2: "51")),
+            Build.Ks2Performance.Establishment("100003", x => x.WithRwmHigher(current: "20", prev: "68", prev2: "49")));
+
+        var response = await _sut.Execute(Request("100001"));
+        var topPerformers = response.AchievedHigherStandardRwm.TopPerformers;
+
+        topPerformers.Should().BeEquivalentTo([
+            new TopPerformer(1, "100002", "Test School AAA", 20, IsCurrentSchool: false),
+            new TopPerformer(2, "100003", "Test School BBB", 20, IsCurrentSchool: false),
+            new TopPerformer(3, "100001", "Test School CCC", 20, IsCurrentSchool: true)
+        ]);
+    }
+
+    [Fact]
+    public async Task AchievedHigherStandardRwm_TopPerfomers_LimitedToTop3()
+    {
+        _establishmentRepo.SetupEstablishments(
+            Build.Establishment("100001", "Test School 1", x => x.Primary()),
+            Build.Establishment("100002", "Test School 2", x => x.Primary()),
+            Build.Establishment("100003", "Test School 3", x => x.Primary()),
+            Build.Establishment("100004", "Test School 4", x => x.Primary()),
+            Build.Establishment("100005", "Test School 5", x => x.Primary()));
+
+        _similarSchoolsRepo.SetupGroups(
+            Build.PrimaryGroup("100001", ["100002", "100003", "100004", "100005"]));
+
+        _performanceRepo.SetupEstablishmentPerformance(
+            Build.Ks2Performance.Establishment("100001", x => x.WithRwmHigher(current: "18", prev: "75", prev2: "80")),
+            Build.Ks2Performance.Establishment("100002", x => x.WithRwmHigher(current: "20", prev: "70", prev2: "50")),
+            Build.Ks2Performance.Establishment("100003", x => x.WithRwmHigher(current: "21", prev: "69", prev2: "51")),
+            Build.Ks2Performance.Establishment("100004", x => x.WithRwmHigher(current: "22", prev: "68", prev2: "49")),
+            Build.Ks2Performance.Establishment("100005", x => x.WithRwmHigher(current: "19", prev: "61", prev2: "67")));
+
+        var response = await _sut.Execute(Request("100001"));
+        var topPerformers = response.AchievedHigherStandardRwm.TopPerformers;
+
+        topPerformers.Should().BeEquivalentTo([
+            new TopPerformer(1, "100004", "Test School 4", 22, IsCurrentSchool: false),
+            new TopPerformer(2, "100003", "Test School 3", 21, IsCurrentSchool: false),
+            new TopPerformer(3, "100002", "Test School 2", 20, IsCurrentSchool: false)
+        ]);
+    }
+
+    [InlineData(Ks2HigherRwm.Filters.Subject.Values.Reading)]
+    [InlineData(Ks2HigherRwm.Filters.Subject.Values.Writing)]
+    [InlineData(Ks2HigherRwm.Filters.Subject.Values.Maths)]
+    [Theory]
+    public async Task AchievedHigherStandardRwm_FilterBy_Subject_WhenMissingEmptyOrInvalidValuesForSelectedSubject_ContainsNullValues(string subject)
+    {
+        _establishmentRepo.SetupEstablishments(
+            Build.Establishment("100001", "Test School 1", x => x.Primary().InLA("001")),
+            Build.Establishment("100002", "Test School 2", x => x.Primary().InLA("001")),
+            Build.Establishment("100003", "Test School 3", x => x.Primary().InLA("001")));
+
+        _similarSchoolsRepo.SetupGroups(
+            Build.PrimaryGroup("100001", ["100002", "100003"]));
+
+        _performanceRepo.SetupEstablishmentPerformance(
+            Build.Ks2Performance.Establishment("100001", x => x
+                .WithRwmHigher(current: "81", prev: "80", prev2: "79")
+                .WithRwmHigherWriting(current: "", prev: "", prev2: "")
+                .WithRwmHigherMaths(current: "x", prev: "y", prev2: "z")),
+            Build.Ks2Performance.Establishment("100002", x => x
+                .WithRwmHigher(current: "81", prev: "80", prev2: "79")
+                .WithRwmHigherWriting(current: "", prev: "", prev2: "")
+                .WithRwmHigherMaths(current: "x", prev: "y", prev2: "z")),
+            Build.Ks2Performance.Establishment("100003", x => x
+                .WithRwmHigher(current: "81", prev: "80", prev2: "79")
+                .WithRwmHigherWriting(current: "", prev: "", prev2: "")
+                .WithRwmHigherMaths(current: "x", prev: "y", prev2: "z")));
+
+        _performanceRepo.SetupLAPerformance(
+             Build.Ks2Performance.LA("001", x => x
+                .WithRwmHigher(current: "81", prev: "80", prev2: "79")
+                .WithRwmHigherWriting(current: "", prev: "", prev2: "")
+                .WithRwmHigherMaths(current: "x", prev: "y", prev2: "z")));
+
+        _performanceRepo.SetupEnglandPerformance(
+            Build.Ks2Performance.England(x => x
+                .WithRwmHigher(current: "81", prev: "80", prev2: "79")
+                .WithRwmHigherWriting(current: "", prev: "", prev2: "")
+                .WithRwmHigherMaths(current: "x", prev: "y", prev2: "z")));
+
+        var response = await _sut.Execute(Request("100001", filterBy: new()
+        {
+            [Ks2HigherRwm.Filters.Subject.Key] = subject
+        }));
+
+        var series = response.AchievedHigherStandardRwm.Series;
+
+        series.Should().NotBeNull();
+        series.Should().Equal(
+            new MeasureSeries(MeasureSeriesType.CurrentSchool, null, null, null),
+            new MeasureSeries(MeasureSeriesType.SimilarSchoolsAverage, null, null, null),
+            new MeasureSeries(MeasureSeriesType.LASchoolsAverage, null, null, null),
+            new MeasureSeries(MeasureSeriesType.EnglandSchoolsAverage, null, null, null));
+    }
+
+    [InlineData(Ks2HigherRwm.Filters.Subject.Values.Reading, new[] { 72.0, 71.0, 70.0 }, new[] { 71.0, 70.0, 69.0 }, new[] { 73.0, 72.0, 71.0 }, new[] { 74.0, 73.0, 72.0 })]
+    [InlineData(Ks2HigherRwm.Filters.Subject.Values.Writing, new[] { 62.0, 61.0, 60.0 }, new[] { 61.0, 60.0, 59.0 }, new[] { 63.0, 62.0, 61.0 }, new[] { 64.0, 63.0, 62.0 })]
+    [InlineData(Ks2HigherRwm.Filters.Subject.Values.Maths, new[] { 52.0, 51.0, 50.0 }, new[] { 51.0, 50.0, 49.0 }, new[] { 53.0, 52.0, 51.0 }, new[] { 54.0, 53.0, 52.0 })]
+    [InlineData(Ks2HigherRwm.Filters.Subject.Values.ReadingWritingMaths, new[] { 82.0, 81.0, 80.0 }, new[] { 81.0, 80.0, 79.0 }, new[] { 83.0, 82.0, 81.0 }, new[] { 84.0, 83.0, 82.0 })]
+    // Empty or invalid filter values default to ReadingWritingMaths
+    [InlineData("", new[] { 82.0, 81.0, 80.0 }, new[] { 81.0, 80.0, 79.0 }, new[] { 83.0, 82.0, 81.0 }, new[] { 84.0, 83.0, 82.0 })]
+    [InlineData("xyz", new[] { 82.0, 81.0, 80.0 }, new[] { 81.0, 80.0, 79.0 }, new[] { 83.0, 82.0, 81.0 }, new[] { 84.0, 83.0, 82.0 })]
+    [Theory]
+    public async Task AchievedHigherStandardRwm_FilterBy_Subject_ContainsYearByYearValuesForSelectedSubject(string subject, double[] currentSchool, double[] similarSchools, double[] la, double[] england)
+    {
+        _establishmentRepo.SetupEstablishments(
+            Build.Establishment("100001", "Test School 1", x => x.Primary().InLA("001")),
+            Build.Establishment("100002", "Test School 2", x => x.Primary().InLA("001")),
+            Build.Establishment("100003", "Test School 3", x => x.Primary().InLA("001")));
+
+        _similarSchoolsRepo.SetupGroups(
+            Build.PrimaryGroup("100001", ["100002", "100003"]));
+
+        _performanceRepo.SetupEstablishmentPerformance(
+            Build.Ks2Performance.Establishment("100001", x => x
+                .WithRwmHigher(current: "82", prev: "81", prev2: "80")
+                .WithRwmHigherReading(current: "72", prev: "71", prev2: "70")
+                .WithRwmHigherWriting(current: "62", prev: "61", prev2: "60")
+                .WithRwmHigherMaths(current: "52", prev: "51", prev2: "50")),
+            Build.Ks2Performance.Establishment("100002", x => x
+                .WithRwmHigher(current: "81", prev: "80", prev2: "79")
+                .WithRwmHigherReading(current: "72", prev: "71", prev2: "70")
+                .WithRwmHigherWriting(current: "60", prev: "59", prev2: "58")
+                .WithRwmHigherMaths(current: "52", prev: "51", prev2: "50")),
+            Build.Ks2Performance.Establishment("100003", x => x
+                .WithRwmHigher(current: "81", prev: "80", prev2: "79")
+                .WithRwmHigherReading(current: "70", prev: "69", prev2: "68")
+                .WithRwmHigherWriting(current: "62", prev: "61", prev2: "60")
+                .WithRwmHigherMaths(current: "50", prev: "49", prev2: "48")));
+
+        _performanceRepo.SetupLAPerformance(
+             Build.Ks2Performance.LA("001", x => x
+                .WithRwmHigher(current: "83", prev: "82", prev2: "81")
+                .WithRwmHigherReading(current: "73", prev: "72", prev2: "71")
+                .WithRwmHigherWriting(current: "63", prev: "62", prev2: "61")
+                .WithRwmHigherMaths(current: "53", prev: "52", prev2: "51")));
+
+        _performanceRepo.SetupEnglandPerformance(
+            Build.Ks2Performance.England(x => x
+                .WithRwmHigher(current: "84", prev: "83", prev2: "82")
+                .WithRwmHigherReading(current: "74", prev: "73", prev2: "72")
+                .WithRwmHigherWriting(current: "64", prev: "63", prev2: "62")
+                .WithRwmHigherMaths(current: "54", prev: "53", prev2: "52")));
+
+        var response = await _sut.Execute(Request("100001", filterBy: new()
+        {
+            [Ks2HigherRwm.Filters.Subject.Key] = subject
+        }));
+
+        var series = response.AchievedHigherStandardRwm.Series;
+
+        series.Should().NotBeNull();
+        series.Should().Equal([
+            new MeasureSeries(MeasureSeriesType.CurrentSchool, (decimal?)currentSchool[0], (decimal?)currentSchool[1], (decimal?)currentSchool[2]),
+            new MeasureSeries(MeasureSeriesType.SimilarSchoolsAverage, (decimal?)similarSchools[0], (decimal?)similarSchools[1], (decimal?)similarSchools[2]),
+            new MeasureSeries(MeasureSeriesType.LASchoolsAverage, (decimal?)la[0], (decimal?)la[1], (decimal?)la[2]),
+            new MeasureSeries(MeasureSeriesType.EnglandSchoolsAverage, (decimal?)england[0], (decimal?)england[1], (decimal?)england[2])
+        ]);
+    }
+
+    [InlineData(Ks2HigherRwm.Filters.Subject.Values.Reading, new[] { "100001", "100002", "100003" })]
+    [InlineData(Ks2HigherRwm.Filters.Subject.Values.Writing, new[] { "100004", "100003", "100002" })]
+    [InlineData(Ks2HigherRwm.Filters.Subject.Values.Maths, new[] { "100003", "100001", "100002" })]
+    [InlineData(Ks2HigherRwm.Filters.Subject.Values.ReadingWritingMaths, new[] { "100002", "100003", "100004" })]
+    [Theory]
+    public async Task AchievedHigherStandardRwm_FilterBy_Subject_TopPerfomers_RanksSimilarSchoolsBasedOnCurrentYearValueForSelectedSubject(string subject, string[] expected)
+    {
+        _establishmentRepo.SetupEstablishments(
+            Build.Establishment("100001", "Test School 1", x => x.Primary()),
+            Build.Establishment("100002", "Test School 2", x => x.Primary()),
+            Build.Establishment("100003", "Test School 3", x => x.Primary()),
+            Build.Establishment("100004", "Test School 4", x => x.Primary()));
+
+        _similarSchoolsRepo.SetupGroups(
+            Build.PrimaryGroup("100001", ["100002", "100003", "100004"]));
+
+        _performanceRepo.SetupEstablishmentPerformance(
+            Build.Ks2Performance.Establishment("100001", x => x
+                .WithRwmHigher(current: "1", prev: "", prev2: "")
+                .WithRwmHigherReading(current: "30", prev: "", prev2: "")
+                .WithRwmHigherWriting(current: "96", prev: "", prev2: "")
+                .WithRwmHigherMaths(current: "50", prev: "", prev2: "")),
+            Build.Ks2Performance.Establishment("100002", x => x
+                .WithRwmHigher(current: "4", prev: "", prev2: "")
+                .WithRwmHigherReading(current: "20", prev: "", prev2: "")
+                .WithRwmHigherWriting(current: "97", prev: "", prev2: "")
+                .WithRwmHigherMaths(current: "40", prev: "", prev2: "")),
+            Build.Ks2Performance.Establishment("100003", x => x
+                .WithRwmHigher(current: "3", prev: "", prev2: "")
+                .WithRwmHigherReading(current: "10", prev: "", prev2: "")
+                .WithRwmHigherWriting(current: "98", prev: "", prev2: "")
+                .WithRwmHigherMaths(current: "60", prev: "", prev2: "")),
+            Build.Ks2Performance.Establishment("100004", x => x
+                .WithRwmHigher(current: "2", prev: "", prev2: "")
+                .WithRwmHigherReading(current: "0", prev: "", prev2: "")
+                .WithRwmHigherWriting(current: "99", prev: "", prev2: "")
+                .WithRwmHigherMaths(current: "30", prev: "", prev2: "")));
+
+        var response = await _sut.Execute(Request("100001", filterBy: new()
+        {
+            [Ks2HigherRwm.Filters.Subject.Key] = subject
+        }));
+
+        var topPerformers = response.AchievedHigherStandardRwm.TopPerformers;
 
         topPerformers.Should().NotBeNullOrEmpty();
         topPerformers.Select(tp => tp.Urn).Should().Equal(expected);

--- a/Tests/SAPSec.Test.Common/Builders/EnglandPerformanceBuilder.cs
+++ b/Tests/SAPSec.Test.Common/Builders/EnglandPerformanceBuilder.cs
@@ -16,6 +16,18 @@ public class EnglandPerformanceBuilder()
     string RwmExpected_Maths_Tot_Cohort_Eng_Current_Num = string.Empty;
     string RwmExpected_Maths_Tot_Cohort_Eng_Previous_Num = string.Empty;
     string RwmExpected_Maths_Tot_Cohort_Eng_Previous2_Num = string.Empty;
+    string RwmHigher_Tot_Cohort_Eng_Current_Num = string.Empty;
+    string RwmHigher_Tot_Cohort_Eng_Previous_Num = string.Empty;
+    string RwmHigher_Tot_Cohort_Eng_Previous2_Num = string.Empty;
+    string RwmHigher_Reading_Tot_Cohort_Eng_Current_Num = string.Empty;
+    string RwmHigher_Reading_Tot_Cohort_Eng_Previous_Num = string.Empty;
+    string RwmHigher_Reading_Tot_Cohort_Eng_Previous2_Num = string.Empty;
+    string RwmHigher_Writing_Tot_Cohort_Eng_Current_Num = string.Empty;
+    string RwmHigher_Writing_Tot_Cohort_Eng_Previous_Num = string.Empty;
+    string RwmHigher_Writing_Tot_Cohort_Eng_Previous2_Num = string.Empty;
+    string RwmHigher_Maths_Tot_Cohort_Eng_Current_Num = string.Empty;
+    string RwmHigher_Maths_Tot_Cohort_Eng_Previous_Num = string.Empty;
+    string RwmHigher_Maths_Tot_Cohort_Eng_Previous2_Num = string.Empty;
     string ReadingScaledScore_Tot_Cohort_Eng_Current_Num = string.Empty;
     string ReadingScaledScore_Tot_Cohort_Eng_Previous_Num = string.Empty;
     string ReadingScaledScore_Tot_Cohort_Eng_Previous2_Num = string.Empty;
@@ -34,24 +46,6 @@ public class EnglandPerformanceBuilder()
         RwmExpected_Tot_Cohort_Eng_Current_Num = current;
         RwmExpected_Tot_Cohort_Eng_Previous_Num = prev;
         RwmExpected_Tot_Cohort_Eng_Previous2_Num = prev2;
-
-        return this;
-    }
-
-    public EnglandPerformanceBuilder WithReadingScaledScore(string current, string prev, string prev2)
-    {
-        ReadingScaledScore_Tot_Cohort_Eng_Current_Num = current;
-        ReadingScaledScore_Tot_Cohort_Eng_Previous_Num = prev;
-        ReadingScaledScore_Tot_Cohort_Eng_Previous2_Num = prev2;
-
-        return this;
-    }
-
-    public EnglandPerformanceBuilder WithMathsScaledScore(string current, string prev, string prev2)
-    {
-        MathsScaledScore_Tot_Cohort_Eng_Current_Num = current;
-        MathsScaledScore_Tot_Cohort_Eng_Previous_Num = prev;
-        MathsScaledScore_Tot_Cohort_Eng_Previous2_Num = prev2;
 
         return this;
     }
@@ -79,6 +73,60 @@ public class EnglandPerformanceBuilder()
         RwmExpected_Maths_Tot_Cohort_Eng_Current_Num = current;
         RwmExpected_Maths_Tot_Cohort_Eng_Previous_Num = prev;
         RwmExpected_Maths_Tot_Cohort_Eng_Previous2_Num = prev2;
+
+        return this;
+    }
+
+    public EnglandPerformanceBuilder WithRwmHigher(string current, string prev, string prev2)
+    {
+        RwmHigher_Tot_Cohort_Eng_Current_Num = current;
+        RwmHigher_Tot_Cohort_Eng_Previous_Num = prev;
+        RwmHigher_Tot_Cohort_Eng_Previous2_Num = prev2;
+
+        return this;
+    }
+
+    public EnglandPerformanceBuilder WithRwmHigherReading(string current, string prev, string prev2)
+    {
+        RwmHigher_Reading_Tot_Cohort_Eng_Current_Num = current;
+        RwmHigher_Reading_Tot_Cohort_Eng_Previous_Num = prev;
+        RwmHigher_Reading_Tot_Cohort_Eng_Previous2_Num = prev2;
+
+        return this;
+    }
+
+    public EnglandPerformanceBuilder WithRwmHigherWriting(string current, string prev, string prev2)
+    {
+        RwmHigher_Writing_Tot_Cohort_Eng_Current_Num = current;
+        RwmHigher_Writing_Tot_Cohort_Eng_Previous_Num = prev;
+        RwmHigher_Writing_Tot_Cohort_Eng_Previous2_Num = prev2;
+
+        return this;
+    }
+
+    public EnglandPerformanceBuilder WithRwmHigherMaths(string current, string prev, string prev2)
+    {
+        RwmHigher_Maths_Tot_Cohort_Eng_Current_Num = current;
+        RwmHigher_Maths_Tot_Cohort_Eng_Previous_Num = prev;
+        RwmHigher_Maths_Tot_Cohort_Eng_Previous2_Num = prev2;
+
+        return this;
+    }
+
+    public EnglandPerformanceBuilder WithReadingScaledScore(string current, string prev, string prev2)
+    {
+        ReadingScaledScore_Tot_Cohort_Eng_Current_Num = current;
+        ReadingScaledScore_Tot_Cohort_Eng_Previous_Num = prev;
+        ReadingScaledScore_Tot_Cohort_Eng_Previous2_Num = prev2;
+
+        return this;
+    }
+
+    public EnglandPerformanceBuilder WithMathsScaledScore(string current, string prev, string prev2)
+    {
+        MathsScaledScore_Tot_Cohort_Eng_Current_Num = current;
+        MathsScaledScore_Tot_Cohort_Eng_Previous_Num = prev;
+        MathsScaledScore_Tot_Cohort_Eng_Previous2_Num = prev2;
 
         return this;
     }
@@ -117,6 +165,18 @@ public class EnglandPerformanceBuilder()
             RwmExpected_Maths_Tot_Cohort_Eng_Current_Num = RwmExpected_Maths_Tot_Cohort_Eng_Current_Num,
             RwmExpected_Maths_Tot_Cohort_Eng_Previous_Num = RwmExpected_Maths_Tot_Cohort_Eng_Previous_Num,
             RwmExpected_Maths_Tot_Cohort_Eng_Previous2_Num = RwmExpected_Maths_Tot_Cohort_Eng_Previous2_Num,
+            RwmHigher_Tot_Cohort_Eng_Current_Num = RwmHigher_Tot_Cohort_Eng_Current_Num,
+            RwmHigher_Tot_Cohort_Eng_Previous_Num = RwmHigher_Tot_Cohort_Eng_Previous_Num,
+            RwmHigher_Tot_Cohort_Eng_Previous2_Num = RwmHigher_Tot_Cohort_Eng_Previous2_Num,
+            RwmHigher_Reading_Tot_Cohort_Eng_Current_Num = RwmHigher_Reading_Tot_Cohort_Eng_Current_Num,
+            RwmHigher_Reading_Tot_Cohort_Eng_Previous_Num = RwmHigher_Reading_Tot_Cohort_Eng_Previous_Num,
+            RwmHigher_Reading_Tot_Cohort_Eng_Previous2_Num = RwmHigher_Reading_Tot_Cohort_Eng_Previous2_Num,
+            RwmHigher_Writing_Tot_Cohort_Eng_Current_Num = RwmHigher_Writing_Tot_Cohort_Eng_Current_Num,
+            RwmHigher_Writing_Tot_Cohort_Eng_Previous_Num = RwmHigher_Writing_Tot_Cohort_Eng_Previous_Num,
+            RwmHigher_Writing_Tot_Cohort_Eng_Previous2_Num = RwmHigher_Writing_Tot_Cohort_Eng_Previous2_Num,
+            RwmHigher_Maths_Tot_Cohort_Eng_Current_Num = RwmHigher_Maths_Tot_Cohort_Eng_Current_Num,
+            RwmHigher_Maths_Tot_Cohort_Eng_Previous_Num = RwmHigher_Maths_Tot_Cohort_Eng_Previous_Num,
+            RwmHigher_Maths_Tot_Cohort_Eng_Previous2_Num = RwmHigher_Maths_Tot_Cohort_Eng_Previous2_Num,
             ReadingScaledScore_Tot_Cohort_Eng_Current_Num = ReadingScaledScore_Tot_Cohort_Eng_Current_Num,
             ReadingScaledScore_Tot_Cohort_Eng_Previous_Num = ReadingScaledScore_Tot_Cohort_Eng_Previous_Num,
             ReadingScaledScore_Tot_Cohort_Eng_Previous2_Num = ReadingScaledScore_Tot_Cohort_Eng_Previous2_Num,

--- a/Tests/SAPSec.Test.Common/Builders/EstablishmentPerformanceBuilder.cs
+++ b/Tests/SAPSec.Test.Common/Builders/EstablishmentPerformanceBuilder.cs
@@ -19,6 +19,15 @@ public class EstablishmentPerformanceBuilder(string urn)
     string RwmHigher_Tot_Cohort_Est_Current_Num = string.Empty;
     string RwmHigher_Tot_Cohort_Est_Previous_Num = string.Empty;
     string RwmHigher_Tot_Cohort_Est_Previous2_Num = string.Empty;
+    string RwmHigher_Reading_Tot_Cohort_Est_Current_Num = string.Empty;
+    string RwmHigher_Reading_Tot_Cohort_Est_Previous_Num = string.Empty;
+    string RwmHigher_Reading_Tot_Cohort_Est_Previous2_Num = string.Empty;
+    string RwmHigher_Writing_Tot_Cohort_Est_Current_Num = string.Empty;
+    string RwmHigher_Writing_Tot_Cohort_Est_Previous_Num = string.Empty;
+    string RwmHigher_Writing_Tot_Cohort_Est_Previous2_Num = string.Empty;
+    string RwmHigher_Maths_Tot_Cohort_Est_Current_Num = string.Empty;
+    string RwmHigher_Maths_Tot_Cohort_Est_Previous_Num = string.Empty;
+    string RwmHigher_Maths_Tot_Cohort_Est_Previous2_Num = string.Empty;
     string ReadingScaledScore_Tot_Cohort_Est_Current_Num = string.Empty;
     string ReadingScaledScore_Tot_Cohort_Est_Previous_Num = string.Empty;
     string ReadingScaledScore_Tot_Cohort_Est_Previous2_Num = string.Empty;
@@ -73,6 +82,33 @@ public class EstablishmentPerformanceBuilder(string urn)
         RwmHigher_Tot_Cohort_Est_Current_Num = current;
         RwmHigher_Tot_Cohort_Est_Previous_Num = prev;
         RwmHigher_Tot_Cohort_Est_Previous2_Num = prev2;
+
+        return this;
+    }
+
+    public EstablishmentPerformanceBuilder WithRwmHigherReading(string current, string prev, string prev2)
+    {
+        RwmHigher_Reading_Tot_Cohort_Est_Current_Num = current;
+        RwmHigher_Reading_Tot_Cohort_Est_Previous_Num = prev;
+        RwmHigher_Reading_Tot_Cohort_Est_Previous2_Num = prev2;
+
+        return this;
+    }
+
+    public EstablishmentPerformanceBuilder WithRwmHigherWriting(string current, string prev, string prev2)
+    {
+        RwmHigher_Writing_Tot_Cohort_Est_Current_Num = current;
+        RwmHigher_Writing_Tot_Cohort_Est_Previous_Num = prev;
+        RwmHigher_Writing_Tot_Cohort_Est_Previous2_Num = prev2;
+
+        return this;
+    }
+
+    public EstablishmentPerformanceBuilder WithRwmHigherMaths(string current, string prev, string prev2)
+    {
+        RwmHigher_Maths_Tot_Cohort_Est_Current_Num = current;
+        RwmHigher_Maths_Tot_Cohort_Est_Previous_Num = prev;
+        RwmHigher_Maths_Tot_Cohort_Est_Previous2_Num = prev2;
 
         return this;
     }
@@ -132,6 +168,15 @@ public class EstablishmentPerformanceBuilder(string urn)
             RwmHigher_Tot_Cohort_Est_Current_Num = RwmHigher_Tot_Cohort_Est_Current_Num,
             RwmHigher_Tot_Cohort_Est_Previous_Num = RwmHigher_Tot_Cohort_Est_Previous_Num,
             RwmHigher_Tot_Cohort_Est_Previous2_Num = RwmHigher_Tot_Cohort_Est_Previous2_Num,
+            RwmHigher_Reading_Tot_Cohort_Est_Current_Num = RwmHigher_Reading_Tot_Cohort_Est_Current_Num,
+            RwmHigher_Reading_Tot_Cohort_Est_Previous_Num = RwmHigher_Reading_Tot_Cohort_Est_Previous_Num,
+            RwmHigher_Reading_Tot_Cohort_Est_Previous2_Num = RwmHigher_Reading_Tot_Cohort_Est_Previous2_Num,
+            RwmHigher_Writing_Tot_Cohort_Est_Current_Num = RwmHigher_Writing_Tot_Cohort_Est_Current_Num,
+            RwmHigher_Writing_Tot_Cohort_Est_Previous_Num = RwmHigher_Writing_Tot_Cohort_Est_Previous_Num,
+            RwmHigher_Writing_Tot_Cohort_Est_Previous2_Num = RwmHigher_Writing_Tot_Cohort_Est_Previous2_Num,
+            RwmHigher_Maths_Tot_Cohort_Est_Current_Num = RwmHigher_Maths_Tot_Cohort_Est_Current_Num,
+            RwmHigher_Maths_Tot_Cohort_Est_Previous_Num = RwmHigher_Maths_Tot_Cohort_Est_Previous_Num,
+            RwmHigher_Maths_Tot_Cohort_Est_Previous2_Num = RwmHigher_Maths_Tot_Cohort_Est_Previous2_Num,
             ReadingScaledScore_Tot_Cohort_Est_Current_Num = ReadingScaledScore_Tot_Cohort_Est_Current_Num,
             ReadingScaledScore_Tot_Cohort_Est_Previous_Num = ReadingScaledScore_Tot_Cohort_Est_Previous_Num,
             ReadingScaledScore_Tot_Cohort_Est_Previous2_Num = ReadingScaledScore_Tot_Cohort_Est_Previous2_Num,

--- a/Tests/SAPSec.Test.Common/Builders/LAPerformanceBuilder.cs
+++ b/Tests/SAPSec.Test.Common/Builders/LAPerformanceBuilder.cs
@@ -16,6 +16,18 @@ public class LAPerformanceBuilder(string laId)
     string RwmExpected_Maths_Tot_Cohort_LA_Current_Num = string.Empty;
     string RwmExpected_Maths_Tot_Cohort_LA_Previous_Num = string.Empty;
     string RwmExpected_Maths_Tot_Cohort_LA_Previous2_Num = string.Empty;
+    string RwmHigher_Tot_Cohort_LA_Current_Num = string.Empty;
+    string RwmHigher_Tot_Cohort_LA_Previous_Num = string.Empty;
+    string RwmHigher_Tot_Cohort_LA_Previous2_Num = string.Empty;
+    string RwmHigher_Reading_Tot_Cohort_LA_Current_Num = string.Empty;
+    string RwmHigher_Reading_Tot_Cohort_LA_Previous_Num = string.Empty;
+    string RwmHigher_Reading_Tot_Cohort_LA_Previous2_Num = string.Empty;
+    string RwmHigher_Writing_Tot_Cohort_LA_Current_Num = string.Empty;
+    string RwmHigher_Writing_Tot_Cohort_LA_Previous_Num = string.Empty;
+    string RwmHigher_Writing_Tot_Cohort_LA_Previous2_Num = string.Empty;
+    string RwmHigher_Maths_Tot_Cohort_LA_Current_Num = string.Empty;
+    string RwmHigher_Maths_Tot_Cohort_LA_Previous_Num = string.Empty;
+    string RwmHigher_Maths_Tot_Cohort_LA_Previous2_Num = string.Empty;
     string ReadingScaledScore_Tot_Cohort_LA_Current_Num = string.Empty;
     string ReadingScaledScore_Tot_Cohort_LA_Previous_Num = string.Empty;
     string ReadingScaledScore_Tot_Cohort_LA_Previous2_Num = string.Empty;
@@ -34,24 +46,6 @@ public class LAPerformanceBuilder(string laId)
         RwmExpected_Tot_Cohort_LA_Current_Num = current;
         RwmExpected_Tot_Cohort_LA_Previous_Num = prev;
         RwmExpected_Tot_Cohort_LA_Previous2_Num = prev2;
-
-        return this;
-    }
-
-    public LAPerformanceBuilder WithReadingScaledScore(string current, string prev, string prev2)
-    {
-        ReadingScaledScore_Tot_Cohort_LA_Current_Num = current;
-        ReadingScaledScore_Tot_Cohort_LA_Previous_Num = prev;
-        ReadingScaledScore_Tot_Cohort_LA_Previous2_Num = prev2;
-
-        return this;
-    }
-
-    public LAPerformanceBuilder WithMathsScaledScore(string current, string prev, string prev2)
-    {
-        MathsScaledScore_Tot_Cohort_LA_Current_Num = current;
-        MathsScaledScore_Tot_Cohort_LA_Previous_Num = prev;
-        MathsScaledScore_Tot_Cohort_LA_Previous2_Num = prev2;
 
         return this;
     }
@@ -79,6 +73,60 @@ public class LAPerformanceBuilder(string laId)
         RwmExpected_Maths_Tot_Cohort_LA_Current_Num = current;
         RwmExpected_Maths_Tot_Cohort_LA_Previous_Num = prev;
         RwmExpected_Maths_Tot_Cohort_LA_Previous2_Num = prev2;
+
+        return this;
+    }
+
+    public LAPerformanceBuilder WithRwmHigher(string current, string prev, string prev2)
+    {
+        RwmHigher_Tot_Cohort_LA_Current_Num = current;
+        RwmHigher_Tot_Cohort_LA_Previous_Num = prev;
+        RwmHigher_Tot_Cohort_LA_Previous2_Num = prev2;
+
+        return this;
+    }
+
+    public LAPerformanceBuilder WithRwmHigherReading(string current, string prev, string prev2)
+    {
+        RwmHigher_Reading_Tot_Cohort_LA_Current_Num = current;
+        RwmHigher_Reading_Tot_Cohort_LA_Previous_Num = prev;
+        RwmHigher_Reading_Tot_Cohort_LA_Previous2_Num = prev2;
+
+        return this;
+    }
+
+    public LAPerformanceBuilder WithRwmHigherWriting(string current, string prev, string prev2)
+    {
+        RwmHigher_Writing_Tot_Cohort_LA_Current_Num = current;
+        RwmHigher_Writing_Tot_Cohort_LA_Previous_Num = prev;
+        RwmHigher_Writing_Tot_Cohort_LA_Previous2_Num = prev2;
+
+        return this;
+    }
+
+    public LAPerformanceBuilder WithRwmHigherMaths(string current, string prev, string prev2)
+    {
+        RwmHigher_Maths_Tot_Cohort_LA_Current_Num = current;
+        RwmHigher_Maths_Tot_Cohort_LA_Previous_Num = prev;
+        RwmHigher_Maths_Tot_Cohort_LA_Previous2_Num = prev2;
+
+        return this;
+    }
+
+    public LAPerformanceBuilder WithReadingScaledScore(string current, string prev, string prev2)
+    {
+        ReadingScaledScore_Tot_Cohort_LA_Current_Num = current;
+        ReadingScaledScore_Tot_Cohort_LA_Previous_Num = prev;
+        ReadingScaledScore_Tot_Cohort_LA_Previous2_Num = prev2;
+
+        return this;
+    }
+
+    public LAPerformanceBuilder WithMathsScaledScore(string current, string prev, string prev2)
+    {
+        MathsScaledScore_Tot_Cohort_LA_Current_Num = current;
+        MathsScaledScore_Tot_Cohort_LA_Previous_Num = prev;
+        MathsScaledScore_Tot_Cohort_LA_Previous2_Num = prev2;
 
         return this;
     }
@@ -117,6 +165,18 @@ public class LAPerformanceBuilder(string laId)
             RwmExpected_Maths_Tot_Cohort_LA_Current_Num = RwmExpected_Maths_Tot_Cohort_LA_Current_Num,
             RwmExpected_Maths_Tot_Cohort_LA_Previous_Num = RwmExpected_Maths_Tot_Cohort_LA_Previous_Num,
             RwmExpected_Maths_Tot_Cohort_LA_Previous2_Num = RwmExpected_Maths_Tot_Cohort_LA_Previous2_Num,
+            RwmHigher_Tot_Cohort_LA_Current_Num = RwmHigher_Tot_Cohort_LA_Current_Num,
+            RwmHigher_Tot_Cohort_LA_Previous_Num = RwmHigher_Tot_Cohort_LA_Previous_Num,
+            RwmHigher_Tot_Cohort_LA_Previous2_Num = RwmHigher_Tot_Cohort_LA_Previous2_Num,
+            RwmHigher_Reading_Tot_Cohort_LA_Current_Num = RwmHigher_Reading_Tot_Cohort_LA_Current_Num,
+            RwmHigher_Reading_Tot_Cohort_LA_Previous_Num = RwmHigher_Reading_Tot_Cohort_LA_Previous_Num,
+            RwmHigher_Reading_Tot_Cohort_LA_Previous2_Num = RwmHigher_Reading_Tot_Cohort_LA_Previous2_Num,
+            RwmHigher_Writing_Tot_Cohort_LA_Current_Num = RwmHigher_Writing_Tot_Cohort_LA_Current_Num,
+            RwmHigher_Writing_Tot_Cohort_LA_Previous_Num = RwmHigher_Writing_Tot_Cohort_LA_Previous_Num,
+            RwmHigher_Writing_Tot_Cohort_LA_Previous2_Num = RwmHigher_Writing_Tot_Cohort_LA_Previous2_Num,
+            RwmHigher_Maths_Tot_Cohort_LA_Current_Num = RwmHigher_Maths_Tot_Cohort_LA_Current_Num,
+            RwmHigher_Maths_Tot_Cohort_LA_Previous_Num = RwmHigher_Maths_Tot_Cohort_LA_Previous_Num,
+            RwmHigher_Maths_Tot_Cohort_LA_Previous2_Num = RwmHigher_Maths_Tot_Cohort_LA_Previous2_Num,
             ReadingScaledScore_Tot_Cohort_LA_Current_Num = ReadingScaledScore_Tot_Cohort_LA_Current_Num,
             ReadingScaledScore_Tot_Cohort_LA_Previous_Num = ReadingScaledScore_Tot_Cohort_LA_Previous_Num,
             ReadingScaledScore_Tot_Cohort_LA_Previous2_Num = ReadingScaledScore_Tot_Cohort_LA_Previous2_Num,

--- a/Tests/SAPSec.Test.EndToEnd/Ks2PerformanceMeasuresPageEndToEndTests.cs
+++ b/Tests/SAPSec.Test.EndToEnd/Ks2PerformanceMeasuresPageEndToEndTests.cs
@@ -15,6 +15,7 @@ public class Ks2PerformanceMeasuresPageEndToEndTests(EndToEndTestsFixture fixtur
 {
     private const string UrlPattern = @"\d{6}";
     private const string MeetingExpectedStandardHeaderText = "Meeting expected standard in reading, writing and maths";
+    private const string AchievedHigherStandardHeaderText = "Achieved a higher standard in reading, writing and maths";
     private const string ReadingScaledScoreHeaderText = "Average scaled score in reading";
     private const string MeetingExpectedStandardGpsHeaderText = "Meeting expected standard in grammar, punctuation and spelling";
     private const string AchievedHigherStandardGpsHeaderText = "Achieved a higher standard in grammar, punctuation and spelling";
@@ -125,6 +126,118 @@ public class Ks2PerformanceMeasuresPageEndToEndTests(EndToEndTestsFixture fixtur
     public async Task MeetingExpectedStandardRwm_ChangeSubjectFilters()
     {
         var section = await GetSection(MeetingExpectedStandardHeaderText);
+        await section.GetByRole(AriaRole.Tab, new() { Name = "Table" }).ClickAsync();
+
+        var table = section.GetByRole(AriaRole.Table);
+        await Expect(table).ToBeVisibleAsync();
+
+        List<IEnumerable<string>> subjectValues = [];
+
+        subjectValues.Add(await (table.GetCells()).AllTrimmedTextContentsAsync());
+
+        foreach (var subject in new[] { "Reading", "Writing", "Maths" })
+        {
+            await section.GetByRole(AriaRole.Combobox, new() { Name = "Subject" }).SelectOptionAsync(subject);
+            await table.WaitForDomToStopChanging();
+
+            subjectValues.Add(await (table.GetCells()).AllTrimmedTextContentsAsync());
+        }
+
+        subjectValues.Should().AllBeDifferent();
+    }
+
+    [Fact]
+    public async Task AchievedHigherStandardRwm_ToggleBetweenYearByYearAndCurrentYearView()
+    {
+        var section = await GetSection(AchievedHigherStandardHeaderText);
+        var panel = section.GetByRole(AriaRole.Tabpanel);
+
+        await section.GetByRole(AriaRole.Tab, new() { Name = "Charts" }).ClickAsync();
+
+        var currentYearHeader = section.GetByRole(AriaRole.Heading, new() { Name = "2024 to 2025" });
+        var yearByYearHeader = section.GetByRole(AriaRole.Heading, new() { Name = "Year by year" });
+
+        var showYearByYearButton = section.GetByRole(AriaRole.Button, new() { Name = "Show year by year" });
+        var showCurrentYearButton = section.GetByRole(AriaRole.Button, new() { Name = "Show 2024 to 2025" });
+
+        await Expect(currentYearHeader).ToBeVisibleAsync();
+        await Expect(yearByYearHeader).ToBeHiddenAsync();
+
+        await Expect(showYearByYearButton).ToBeVisibleAsync();
+        await Expect(showCurrentYearButton).ToBeHiddenAsync();
+
+        await showYearByYearButton.ClickAsync();
+
+        await Expect(currentYearHeader).ToBeHiddenAsync();
+        await Expect(yearByYearHeader).ToBeVisibleAsync();
+
+        await Expect(showCurrentYearButton).ToBeVisibleAsync();
+        await Expect(showYearByYearButton).ToBeHiddenAsync();
+
+        await showCurrentYearButton.ClickAsync();
+
+        await Expect(currentYearHeader).ToBeVisibleAsync();
+        await Expect(yearByYearHeader).ToBeHiddenAsync();
+
+        await Expect(showYearByYearButton).ToBeVisibleAsync();
+        await Expect(showCurrentYearButton).ToBeHiddenAsync();
+    }
+
+    [Fact]
+    public async Task AchievedHigherStandardRwm_ViewAndNavigateToTopPerfomers()
+    {
+        var section = await GetSection(AchievedHigherStandardHeaderText);
+        var topPerfomersTab = section.GetByRole(AriaRole.Tab, new() { Name = "Top performers" });
+        await topPerfomersTab.ClickAsync();
+
+        var table = section.GetByRole(AriaRole.Table);
+        await Expect(table).ToBeVisibleAsync();
+
+        var values = await table.GetTableColumnAsync("2024 to 2025");
+        await Expect(values).ToBePercentageValuesHavingCount(3);
+
+        var schools = await table.GetTableColumnAsync("School");
+        await Expect(schools).ToHaveCountAsync(3);
+
+        var schoolLinks = schools.GetByRole(AriaRole.Link);
+        await schoolLinks.Nth(0).ClickAsync();
+
+        await Expect(Page).ToHaveURLAsync(new Regex(PrimarySchoolRoute.SimilarSchoolComparison(UrlPattern)));
+
+        await Page.GoBackAsync();
+
+        await Expect(section).ToBeVisibleAsync();
+        await Expect(topPerfomersTab).ToBeVisibleAsync();
+        await topPerfomersTab.ClickAsync();
+
+        await section.GetByText("See all similar schools").ClickAsync();
+
+        await Expect(Page).ToHaveURLAsync(PrimarySchoolRoute.ViewSimilarSchools);
+    }
+
+    [Fact]
+    public async Task AchievedHigherStandardRwm_ViewTableView()
+    {
+        var section = await GetSection(AchievedHigherStandardHeaderText);
+        await section.GetByRole(AriaRole.Tab, new() { Name = "Table" }).ClickAsync();
+
+        var table = section.GetByRole(AriaRole.Table);
+        await Expect(table).ToBeVisibleAsync();
+
+        var previous2 = await table.GetTableColumnAsync("2022 to 2023");
+        await Expect(previous2).ToBePercentageValuesHavingCount(4);
+
+        var previous = await table.GetTableColumnAsync("2023 to 2024");
+        await Expect(previous).ToBePercentageValuesHavingCount(4);
+
+        var current = await table.GetTableColumnAsync("2024 to 2025");
+        await Expect(current).ToBePercentageValuesHavingCount(4);
+    }
+
+    [Fact]
+    public async Task AchievedHigherStandardRwm_ChangeSubjectFilters()
+    {
+        var section = await GetSection(AchievedHigherStandardHeaderText);
         await section.GetByRole(AriaRole.Tab, new() { Name = "Table" }).ClickAsync();
 
         var table = section.GetByRole(AriaRole.Table);

--- a/Tests/SAPSec.Test.Integration/Tests/Primary/Ks2PerformanceMeasuresPageIntegrationTests.cs
+++ b/Tests/SAPSec.Test.Integration/Tests/Primary/Ks2PerformanceMeasuresPageIntegrationTests.cs
@@ -243,6 +243,223 @@ public class Ks2PerformanceMeasuresPageIntegrationTests(
     }
 
     [Fact]
+    public async Task AchievedHigherStandardRwm_MeasureExistsOnPage()
+    {
+        Fixture.EstablishmentRepository.SetupEstablishments(
+            Build.Establishment("100001", "Test School 1", x => x.Open().Primary().InLA("001")));
+
+        var page = await Fixture.RequestPageAsync(Routes.PrimarySchool("100001").KS2, HttpStatusCode.OK);
+
+        var heading = page.ElementWithTestIdShouldExist("higher-rwm-heading");
+        heading.TrimmedTextContent().Should().Be("Achieved a higher standard in reading, writing and maths");
+    }
+
+    [Fact]
+    public async Task AchievedHigherStandardRwm_TableView_ShouldShowCorrectValues()
+    {
+        Fixture.EstablishmentRepository.SetupEstablishments(
+            Build.Establishment("100001", "Test School 1", x => x.Open().Primary().InLA("001")),
+            Build.Establishment("100002", "Test School 2", x => x.Open().Primary().InLA("002")),
+            Build.Establishment("100003", "Test School 3", x => x.Open().Primary().InLA("003")));
+
+        Fixture.SimilarSchoolsPrimaryRepository.SetupGroups(
+            Build.PrimaryGroup("100001", ["100002", "100003"]));
+
+        Fixture.Ks2PerformanceRepository.SetupEstablishmentPerformance(
+            Build.Ks2Performance.Establishment("100001", x => x.WithRwmHigher(current: "81", prev: "80", prev2: "79")),
+            Build.Ks2Performance.Establishment("100002", x => x.WithRwmHigher(current: "71", prev: "70", prev2: "69")),
+            Build.Ks2Performance.Establishment("100002", x => x.WithRwmHigher(current: "71", prev: "70", prev2: "69")));
+
+        Fixture.Ks2PerformanceRepository.SetupEnglandPerformance(
+            Build.Ks2Performance.England(x => x.WithRwmHigher(current: "101", prev: "100", prev2: "99")));
+
+        Fixture.Ks2PerformanceRepository.SetupLAPerformance(
+            Build.Ks2Performance.LA("001", x => x.WithRwmHigher(current: "91", prev: "90", prev2: "89")));
+
+        var page = await Fixture.RequestPageAsync(Routes.PrimarySchool("100001").KS2, HttpStatusCode.OK);
+
+        var table = page.ElementWithTestIdShouldExist<IHtmlTableElement>("higher-rwm-table-view-table");
+
+        table.ShouldHaveRows(
+            ["School(s)", "2022 to 2023", "2023 to 2024", "2024 to 2025"],
+            ["Test School 1", "79%", "80%", "81%"],
+            ["Similar schools average", "69%", "70%", "71%"],
+            ["Local authority schools average", "89%", "90%", "91%"],
+            ["Schools in England average", "99%", "100%", "101%"]);
+    }
+
+    [Fact]
+    public async Task AchievedHigherStandardRwm_TableView_ValuesRoundTo0DecimalPlaces()
+    {
+        Fixture.EstablishmentRepository.SetupEstablishments(
+            Build.Establishment("100001", "Test School 1", x => x.Open().Primary().InLA("001")),
+            Build.Establishment("100002", "Test School 2", x => x.Open().Primary().InLA("002")),
+            Build.Establishment("100003", "Test School 3", x => x.Open().Primary().InLA("003")));
+
+        Fixture.SimilarSchoolsPrimaryRepository.SetupGroups(
+            Build.PrimaryGroup("100001", ["100002", "100003"]));
+
+        Fixture.Ks2PerformanceRepository.SetupEstablishmentPerformance(
+            Build.Ks2Performance.Establishment("100001", x => x.WithRwmHigher(current: "80.99", prev: "80.3", prev2: "78.9")),
+            Build.Ks2Performance.Establishment("100002", x => x.WithRwmHigher(current: "70.6", prev: "70.3", prev2: "69.1")),
+            Build.Ks2Performance.Establishment("100002", x => x.WithRwmHigher(current: "71.1", prev: "70.2", prev2: "69.3")));
+
+        Fixture.Ks2PerformanceRepository.SetupEnglandPerformance(
+            Build.Ks2Performance.England(x => x.WithRwmHigher(current: "101.31", prev: "99.52", prev2: "99.49")));
+
+        Fixture.Ks2PerformanceRepository.SetupLAPerformance(
+            Build.Ks2Performance.LA("001", x => x.WithRwmHigher(current: "91.02", prev: "89.7", prev2: "89.1")));
+
+        var page = await Fixture.RequestPageAsync(Routes.PrimarySchool("100001").KS2, HttpStatusCode.OK);
+
+        var table = page.ElementWithTestIdShouldExist<IHtmlTableElement>("higher-rwm-table-view-table");
+
+        table.ShouldHaveRows(
+            ["School(s)", "2022 to 2023", "2023 to 2024", "2024 to 2025"],
+            ["Test School 1", "79%", "80%", "81%"],
+            ["Similar schools average", "69%", "70%", "71%"],
+            ["Local authority schools average", "89%", "90%", "91%"],
+            ["Schools in England average", "99%", "100%", "101%"]);
+    }
+
+    [Fact]
+    public async Task AchievedHigherStandardRwm_TopPerformers_ShouldShowCorrectValues()
+    {
+        Fixture.EstablishmentRepository.SetupEstablishments(
+            Build.Establishment("100001", "Test School 1", x => x.Primary()),
+            Build.Establishment("100002", "Test School 2", x => x.Primary()),
+            Build.Establishment("100003", "Test School 3", x => x.Primary()),
+            Build.Establishment("100004", "Test School 4", x => x.Primary()),
+            Build.Establishment("100005", "Test School 5", x => x.Primary()));
+
+        Fixture.SimilarSchoolsPrimaryRepository.SetupGroups(
+            Build.PrimaryGroup("100001", ["100002", "100003", "100004", "100005"]));
+
+        Fixture.Ks2PerformanceRepository.SetupEstablishmentPerformance(
+            Build.Ks2Performance.Establishment("100001", x => x.WithRwmHigher(current: "18", prev: "75", prev2: "80")),
+            Build.Ks2Performance.Establishment("100002", x => x.WithRwmHigher(current: "20", prev: "70", prev2: "50")),
+            Build.Ks2Performance.Establishment("100003", x => x.WithRwmHigher(current: "21", prev: "69", prev2: "51")),
+            Build.Ks2Performance.Establishment("100004", x => x.WithRwmHigher(current: "22", prev: "68", prev2: "49")),
+            Build.Ks2Performance.Establishment("100005", x => x.WithRwmHigher(current: "19", prev: "61", prev2: "67")));
+
+        var page = await Fixture.RequestPageAsync(Routes.PrimarySchool("100001").KS2, HttpStatusCode.OK);
+
+        var table = page.ElementWithTestIdShouldExist<IHtmlTableElement>("higher-rwm-top-performers-table");
+
+        table.ShouldHaveRows(
+            ["Rank", "School", "2024 to 2025"],
+            ["1", "Test School 4", "22%"],
+            ["2", "Test School 3", "21%"],
+            ["3", "Test School 2", "20%"]);
+    }
+
+    [Fact]
+    public async Task AchievedHigherStandardRwm_TopPerformers_ShouldLinkToSimilarSchoolsPage()
+    {
+        Fixture.EstablishmentRepository.SetupEstablishments(
+            Build.Establishment("100001", "Test School 1", x => x.Primary()),
+            Build.Establishment("100002", "Test School 2", x => x.Primary()),
+            Build.Establishment("100003", "Test School 3", x => x.Primary()),
+            Build.Establishment("100004", "Test School 4", x => x.Primary()),
+            Build.Establishment("100005", "Test School 5", x => x.Primary()));
+
+        Fixture.SimilarSchoolsPrimaryRepository.SetupGroups(
+            Build.PrimaryGroup("100001", ["100002", "100003", "100004", "100005"]));
+
+        Fixture.Ks2PerformanceRepository.SetupEstablishmentPerformance(
+            Build.Ks2Performance.Establishment("100001", x => x.WithRwmHigher(current: "18", prev: "75", prev2: "80")),
+            Build.Ks2Performance.Establishment("100002", x => x.WithRwmHigher(current: "20", prev: "70", prev2: "50")),
+            Build.Ks2Performance.Establishment("100003", x => x.WithRwmHigher(current: "21", prev: "69", prev2: "51")),
+            Build.Ks2Performance.Establishment("100004", x => x.WithRwmHigher(current: "22", prev: "68", prev2: "49")),
+            Build.Ks2Performance.Establishment("100005", x => x.WithRwmHigher(current: "19", prev: "61", prev2: "67")));
+
+        var page = await Fixture.RequestPageAsync(Routes.PrimarySchool("100001").KS2, HttpStatusCode.OK);
+
+        var similarSchoolsLink = page.ElementWithTestIdShouldExist("higher-rwm-top-performers-similar-schools-link");
+        similarSchoolsLink.GetAttribute("href").Should().Be(Routes.PrimarySchool("100001").ViewSimilarSchools);
+
+        var table = page.ElementWithTestIdShouldExist<IHtmlTableElement>("higher-rwm-top-performers-table");
+        var topPerfomersLinks = table.QuerySelectorAll("a")
+            .Select(l => l.GetAttribute("href"));
+
+        topPerfomersLinks.Should().BeEquivalentTo([
+            Routes.PrimarySchool("100001").SimilarSchoolComparison("100004"),
+            Routes.PrimarySchool("100001").SimilarSchoolComparison("100003"),
+            Routes.PrimarySchool("100001").SimilarSchoolComparison("100002")
+        ]);
+    }
+
+    [Fact]
+    public async Task AchievedHigherStandardRwm_SubjectFilter_HasExpectedOptions()
+    {
+        Fixture.EstablishmentRepository.SetupEstablishments(
+            Build.Establishment("100001", "Test School 1", x => x.Open().Primary().InLA("001")));
+
+        var page = await Fixture.RequestPageAsync(Routes.PrimarySchool("100001").KS2, HttpStatusCode.OK);
+
+        var filter = page.ElementWithTestIdShouldExist("higher-rwm-subject-filter");
+        filter.ChildTrimmedTextContent().Should().Equal(["Reading, writing and maths", "Reading", "Writing", "Maths"]);
+    }
+
+    [InlineData("Reading", new[] { "70%", "71%", "72%" }, new[] { "69%", "70%", "71%" }, new[] { "71%", "72%", "73%" }, new[] { "72%", "73%", "74%" })]
+    [InlineData("Writing", new[] { "60%", "61%", "62%" }, new[] { "59%", "60%", "61%" }, new[] { "61%", "62%", "63%" }, new[] { "62%", "63%", "64%" })]
+    [InlineData("Maths", new[] { "50%", "51%", "52%" }, new[] { "49%", "50%", "51%" }, new[] { "51%", "52%", "53%" }, new[] { "52%", "53%", "54%" })]
+    [Theory]
+    public async Task AchievedHigherStandardRwm_SubjectFilter_UpdatesTableViewWithSubjectValues(string filterOption, string[] currentSchool, string[] similarSchools, string[] la, string[] england)
+    {
+        Fixture.EstablishmentRepository.SetupEstablishments(
+            Build.Establishment("100001", "Test School 1", x => x.Open().Primary().InLA("001")),
+            Build.Establishment("100002", "Test School 2", x => x.Open().Primary().InLA("002")),
+            Build.Establishment("100003", "Test School 3", x => x.Open().Primary().InLA("003")));
+
+        Fixture.SimilarSchoolsPrimaryRepository.SetupGroups(
+            Build.PrimaryGroup("100001", ["100002", "100003"]));
+
+        Fixture.Ks2PerformanceRepository.SetupEstablishmentPerformance(
+            Build.Ks2Performance.Establishment("100001", x => x
+                .WithRwmHigherReading(current: "72", prev: "71", prev2: "70")
+                .WithRwmHigherWriting(current: "62", prev: "61", prev2: "60")
+                .WithRwmHigherMaths(current: "52", prev: "51", prev2: "50")),
+            Build.Ks2Performance.Establishment("100002", x => x
+                .WithRwmHigherReading(current: "72", prev: "71", prev2: "70")
+                .WithRwmHigherWriting(current: "60", prev: "59", prev2: "58")
+                .WithRwmHigherMaths(current: "52", prev: "51", prev2: "50")),
+            Build.Ks2Performance.Establishment("100003", x => x
+                .WithRwmHigherReading(current: "70", prev: "69", prev2: "68")
+                .WithRwmHigherWriting(current: "62", prev: "61", prev2: "60")
+                .WithRwmHigherMaths(current: "50", prev: "49", prev2: "48")));
+
+        Fixture.Ks2PerformanceRepository.SetupLAPerformance(
+             Build.Ks2Performance.LA("001", x => x
+                .WithRwmHigherReading(current: "73", prev: "72", prev2: "71")
+                .WithRwmHigherWriting(current: "63", prev: "62", prev2: "61")
+                .WithRwmHigherMaths(current: "53", prev: "52", prev2: "51")));
+
+        Fixture.Ks2PerformanceRepository.SetupEnglandPerformance(
+            Build.Ks2Performance.England(x => x
+                .WithRwmHigherReading(current: "74", prev: "73", prev2: "72")
+                .WithRwmHigherWriting(current: "64", prev: "63", prev2: "62")
+                .WithRwmHigherMaths(current: "54", prev: "53", prev2: "52")));
+
+        var page = await Fixture.RequestPageAsync(Routes.PrimarySchool("100001").KS2, HttpStatusCode.OK);
+
+        var filter = page.ElementWithTestIdShouldExist<IHtmlSelectElement>("higher-rwm-subject-filter");
+        filter.SelectOption(filterOption);
+
+        var submitButton = page.ElementWithTestIdShouldExist<IHtmlButtonElement>("higher-rwm-subject-filter-submit");
+        var newPage = await page.SubmitContainingFormAsync(submitButton);
+
+        var table = newPage.ElementWithTestIdShouldExist<IHtmlTableElement>("higher-rwm-table-view-table");
+
+        table.ShouldHaveRows(
+            ["School(s)", "2022 to 2023", "2023 to 2024", "2024 to 2025"],
+            ["Test School 1", .. currentSchool],
+            ["Similar schools average", .. similarSchools],
+            ["Local authority schools average", .. la],
+            ["Schools in England average", .. england]);
+    }
+
+    [Fact]
     public async Task AverageScaledScoreReading_MeasureExistsOnPage()
     {
         Fixture.EstablishmentRepository.SetupEstablishments(


### PR DESCRIPTION
## Description

Adds "Achieved a higher standard in reading, writing and maths" measure to the KS2 performance page, including Subject filter.

## Related Trello Ticket

[PS25: KS2 - Achieving a higher standard in reading, writing and maths - graphs, tables and higher standard details component](https://trello.com/c/WuHmD8YN/839-ps25-ks2-achieving-a-higher-standard-in-reading-writing-and-maths-graphs-tables-and-higher-standard-details-component)
[PS26: 'Achieved a higher standard in reading, writing and maths' subject filters](https://trello.com/c/WwAkvyHr/922-ps26-achieved-a-higher-standard-in-reading-writing-and-maths-subject-filters)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Unit tests added/updated 
- [x] Integration tests added/updated
- [x] Manual testing performed
- [x] Tested on Local/Review

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have verified accessibility requirements are met


## Screenshots

<img width="1189" height="1037" alt="image" src="https://github.com/user-attachments/assets/3b7d9574-33db-49f1-8397-0099aa8c3f2e" />

<img width="1172" height="1259" alt="image" src="https://github.com/user-attachments/assets/3c578985-e6a1-4dd9-b71b-1ce863e55623" />

<img width="1182" height="889" alt="image" src="https://github.com/user-attachments/assets/0f37d9ad-a2ef-4f14-80cf-6e506b7d80d0" />

<img width="1183" height="949" alt="image" src="https://github.com/user-attachments/assets/4561ad64-54ad-4391-bfa3-d664cd3f8a5c" />
