### PR TITLE
fix/text-updated and the barchart fixes

### DIFF
--- a/SAPSec.Core/Features/Measures/Measure.cs
+++ b/SAPSec.Core/Features/Measures/Measure.cs
@@ -26,7 +26,7 @@ public record Measure(
             dataType,
             availableFilters.ToList(),
             MeasureSeries.ForSchool(currentSchool, similarSchools, fieldSelector),
-            TopPerformer.BuildTopPerformers(currentSchool, similarSchools, fieldSelector));
+            TopPerformer.BuildTopPerformers(currentSchool, similarSchools, fieldSelector, dataType));
     }
 
     internal static Measure ForSchoolComparison<T>(

--- a/SAPSec.Core/Features/Measures/TopPerformer.cs
+++ b/SAPSec.Core/Features/Measures/TopPerformer.cs
@@ -12,7 +12,8 @@ public record TopPerformer(
     internal static IReadOnlyCollection<TopPerformer> BuildTopPerformers<T>(
         SchoolData<T> currentSchool,
         IEnumerable<SchoolData<T>> similarSchools,
-        MeasureFieldSelector<T> fieldSelector)
+        MeasureFieldSelector<T> fieldSelector,
+        MeasureDataType dataType)
     {
         return similarSchools
             // Include current school in list
@@ -32,13 +33,19 @@ public record TopPerformer(
             .GroupBy(x => x.Urn, StringComparer.Ordinal)
             .Select(x => x.OrderByDescending(candidate => candidate.IsCurrentSchool).First())
 
-            .OrderByDescending(x => x.Value)
+            .OrderByDescending(x => TopPerformerSortValue(x.Value, dataType))
             .ThenBy(x => x.Name, StringComparer.OrdinalIgnoreCase)
             .Take(3)
             .Select((x, index) => new TopPerformer(index + 1, x.Urn, x.Name, x.Value, x.IsCurrentSchool))
             .ToList()
             .AsReadOnly();
     }
+
+    private static decimal TopPerformerSortValue(decimal? value, MeasureDataType dataType) =>
+        Math.Round(value!.Value, DisplayDecimalPlaces(dataType), MidpointRounding.AwayFromZero);
+
+    private static int DisplayDecimalPlaces(MeasureDataType dataType) =>
+        dataType is MeasureDataType.Score or MeasureDataType.ScaledScore ? 1 : 0;
 
     private sealed record TopPerformerCandidate(
         string Urn,

--- a/SAPSec.Web/Areas/Primary/Views/School/Ks2PerformanceMeasures.cshtml
+++ b/SAPSec.Web/Areas/Primary/Views/School/Ks2PerformanceMeasures.cshtml
@@ -56,8 +56,11 @@
                 </summary>
                 <div class="govuk-details__text">
                     <p class="govuk-body-s govuk-!-margin-bottom-2">
-                        This shows the average reading scaled score for pupils at the end of key stage 2.
-                        Scaled scores typically range from 80 to 120, and a score of 100 represents the expected standard.
+                        This score shows how well pupils performed in the key stage 2 reading test. It is the 
+                        mean scaled score of all pupils who took the test and achieved a scaled score.
+                    </p>
+                    <p class="govuk-body-s govuk-!-margin-bottom-2">
+                        The expected standard is 100 or more. The higher standard is 110 or more.
                     </p>
                 </div>
             </details>
@@ -74,8 +77,11 @@
                 </summary>
                 <div class="govuk-details__text">
                     <p class="govuk-body-s govuk-!-margin-bottom-2">
-                        This shows the average maths scaled score for pupils at the end of key stage 2.
-                        Scaled scores typically range from 80 to 120, and a score of 100 represents the expected standard.
+                        This score shows how well pupils performed in the key stage 2 maths tests. It is the mean 
+                        scaled score of all pupils who took the test and achieved a scaled score.
+                    </p>
+                    <p class="govuk-body-s govuk-!-margin-bottom-2">
+                        The expected standard is 100 or more. The higher standard is 110 or more.
                     </p>
                 </div>
             </details>
@@ -93,7 +99,7 @@
                 <div class="govuk-details__text">
                     <p class="govuk-body-s govuk-!-margin-bottom-2">
                         Pupils achieve the expected standard when they achieve a scaled score of 100 or more
-                        in the grammar, punctuation and spelling test.
+                        in their key stage 2 grammar, punctuation and spelling test.
                     </p>
                 </div>
             </details>
@@ -111,7 +117,7 @@
                 <div class="govuk-details__text">
                     <p class="govuk-body-s govuk-!-margin-bottom-2">
                         Pupils achieve the higher standard when they achieve a scaled score of 110 or more
-                        in the grammar, punctuation and spelling test.
+                        in their key stage 2 grammar, punctuation and spelling test.
                     </p>
                 </div>
             </details>

--- a/SAPSec.Web/Areas/Primary/Views/School/Ks2PerformanceMeasures.cshtml
+++ b/SAPSec.Web/Areas/Primary/Views/School/Ks2PerformanceMeasures.cshtml
@@ -95,7 +95,7 @@
                 </summary>
                 <div class="govuk-details__text">
                     <p class="govuk-body-s govuk-!-margin-bottom-2">
-                        This score shows how well pupils performed in the key stage 2 maths tests. It is the mean 
+                        This score shows how well pupils performed in the key stage 2 maths test. It is the mean 
                         scaled score of all pupils who took the test and achieved a scaled score.
                     </p>
                     <p class="govuk-body-s govuk-!-margin-bottom-2">

--- a/SAPSec.Web/AssetSrc/js/chart-factory.js
+++ b/SAPSec.Web/AssetSrc/js/chart-factory.js
@@ -64,10 +64,11 @@ const CHART_CONFIG = {
         },
         datalabels: {
             anchor: 'end',
-            smallValueAlign: 'end',
+            smallValueAlign: 'right',
             defaultAlign: 'start',
             mobileInsideThresholdRatio: 0.4,
-            offset: 10,
+            defaultOffset: 10,
+            smallValueOffset: 6,
             fontWeight: 'bold'
         },
         noData: {
@@ -175,7 +176,12 @@ function canBarFitLabel(ctx, axisSuffix) {
         return true;
     }
 
-    const barLength = Math.abs(xScale.getPixelForValue(value) - xScale.getPixelForValue(0));
+    const axisMin = typeof xScale.min === 'number' ? xScale.min : 0;
+    const axisMax = typeof xScale.max === 'number' ? xScale.max : 0;
+    const baseValue = axisMin > 0 && value >= axisMin && axisMax > axisMin
+        ? axisMin
+        : 0;
+    const barLength = Math.abs(xScale.getPixelForValue(value) - xScale.getPixelForValue(baseValue));
     const font = Chart.helpers.toFont(ctx.chart.options?.plugins?.datalabels?.font);
 
     canvasContext.save();
@@ -183,7 +189,7 @@ function canBarFitLabel(ctx, axisSuffix) {
     const labelWidth = canvasContext.measureText(getBarLabelText(value, axisSuffix)).width;
     canvasContext.restore();
 
-    return barLength >= labelWidth + (CHART_CONFIG.bar.datalabels.offset * 2);
+    return barLength >= labelWidth + (CHART_CONFIG.bar.datalabels.defaultOffset * 2);
 }
 
 function isMobileViewport() {
@@ -228,6 +234,13 @@ function getBarLabelColor(ctx, gdsStyles, axisSuffix, barLabelAlign) {
     return align === CHART_CONFIG.bar.datalabels.defaultAlign
         ? gdsStyles.onBarLabel
         : gdsStyles.text;
+}
+
+function getBarLabelOffset(ctx, axisSuffix, barLabelAlign) {
+    const align = getBarLabelAlignment(ctx, axisSuffix, barLabelAlign);
+    return align === CHART_CONFIG.bar.datalabels.defaultAlign
+        ? CHART_CONFIG.bar.datalabels.defaultOffset
+        : CHART_CONFIG.bar.datalabels.smallValueOffset;
 }
 
 function buildExplicitTicks(axisMin, axisMax, stepSize) {
@@ -636,7 +649,9 @@ function buildChartOptions(type, gdsStyles, axisStep, axisSuffix, axisMin, axisM
                     align: function (ctx) {
                         return getBarLabelAlignment(ctx, axisSuffix, barLabelAlign);
                     },
-                    offset: CHART_CONFIG.bar.datalabels.offset,
+                    offset: function (ctx) {
+                        return getBarLabelOffset(ctx, axisSuffix, barLabelAlign);
+                    },
                     color: function (ctx) {
                         return getBarLabelColor(ctx, gdsStyles, axisSuffix, barLabelAlign);
                     },
@@ -1017,7 +1032,7 @@ function initAll() {
         return;
     }
 
-    init(document);
+    document.querySelectorAll('.js-chart').forEach(initCharts);
 
     window.addEventListener('scroll', hideAllHtmlTooltips, { passive: true });
     window.addEventListener('resize', hideAllHtmlTooltips, { passive: true });

--- a/SAPSec.Web/Views/Shared/Measures/_CurrentYearChart.cshtml
+++ b/SAPSec.Web/Views/Shared/Measures/_CurrentYearChart.cshtml
@@ -22,7 +22,7 @@
     var (axisMin, axisStep, axisMax) = Model.MeasureInfo.DataType switch
     {
         MeasureDataType.Score => (0, 30, 90),
-        MeasureDataType.ScaledScore => (0, 20, 120),
+        MeasureDataType.ScaledScore => (80, 5, 120),
         _ => (0, 25, 100)
     };
 }

--- a/SAPSec.Web/Views/Shared/Measures/_CurrentYearChart.cshtml
+++ b/SAPSec.Web/Views/Shared/Measures/_CurrentYearChart.cshtml
@@ -22,7 +22,7 @@
     var (axisMin, axisStep, axisMax) = Model.MeasureInfo.DataType switch
     {
         MeasureDataType.Score => (0, 30, 90),
-        MeasureDataType.ScaledScore => (80, 5, 120),
+        MeasureDataType.ScaledScore => (80, 20, 120),
         _ => (0, 25, 100)
     };
 }

--- a/SAPSec.Web/Views/Shared/Measures/_YearByYearChart.cshtml
+++ b/SAPSec.Web/Views/Shared/Measures/_YearByYearChart.cshtml
@@ -30,7 +30,7 @@
     var (axisMin, axisStep, axisMax) = Model.MeasureInfo.DataType switch
     {
         MeasureDataType.Score => (0, 30, 90),
-        MeasureDataType.ScaledScore => (80, 5, 120),
+        MeasureDataType.ScaledScore => (80, 20, 120),
         _ => (0, 25, 100)
     };
 }

--- a/Tests/SAPSec.Core.Tests/Features/Primary/GetSchoolKs2PerformanceMeasuresUseCaseTests.cs
+++ b/Tests/SAPSec.Core.Tests/Features/Primary/GetSchoolKs2PerformanceMeasuresUseCaseTests.cs
@@ -1932,6 +1932,32 @@ public class GetSchoolKs2PerformanceMeasuresUseCaseTests
     }
 
     [Fact]
+    public async Task AchievedHigherStandardGps_TopPerfomers_WhenDisplayedValuesTie_SortsAlphabetically()
+    {
+        _establishmentRepo.SetupEstablishments(
+            Build.Establishment("100001", "Test School 1", x => x.Primary()),
+            Build.Establishment("100002", "Thoresby Primary School", x => x.Primary()),
+            Build.Establishment("100003", "Manor Park Primary Academy", x => x.Primary()),
+            Build.Establishment("100004", "Montem Academy", x => x.Primary()));
+
+        _similarSchoolsRepo.SetupGroups(
+            Build.PrimaryGroup("100001", ["100002", "100003", "100004"]));
+
+        _performanceRepo.SetupEstablishmentPerformance(
+            Build.Ks2Performance.Establishment("100001", x => x.WithGpsHigher(current: "18", prev: "", prev2: "")),
+            Build.Ks2Performance.Establishment("100002", x => x.WithGpsHigher(current: "96.6", prev: "", prev2: "")),
+            Build.Ks2Performance.Establishment("100003", x => x.WithGpsHigher(current: "96.5", prev: "", prev2: "")),
+            Build.Ks2Performance.Establishment("100004", x => x.WithGpsHigher(current: "91.4", prev: "", prev2: "")));
+
+        var response = await _sut.Execute(Request("100001"));
+
+        response.AchievedHigherStandardGps.TopPerformers.Should().Equal(
+            new TopPerformer(1, "100003", "Manor Park Primary Academy", 96.5m, IsCurrentSchool: false),
+            new TopPerformer(2, "100002", "Thoresby Primary School", 96.6m, IsCurrentSchool: false),
+            new TopPerformer(3, "100004", "Montem Academy", 91.4m, IsCurrentSchool: false));
+    }
+
+    [Fact]
     public async Task AverageScaledScoreReading_ShouldContainExpectedMeasureSeries()
     {
         _establishmentRepo.SetupEstablishments(

--- a/Tests/SAPSec.Test.Integration/Tests/Primary/Ks2PerformanceMeasuresPageIntegrationTests.cs
+++ b/Tests/SAPSec.Test.Integration/Tests/Primary/Ks2PerformanceMeasuresPageIntegrationTests.cs
@@ -893,9 +893,9 @@ public class Ks2PerformanceMeasuresPageIntegrationTests(
     {
         Fixture.EstablishmentRepository.SetupEstablishments(
             Build.Establishment("100001", "Test School 1", x => x.Primary()),
-            Build.Establishment("100002", "Test School 2", x => x.Primary()),
-            Build.Establishment("100003", "Test School 3", x => x.Primary()),
-            Build.Establishment("100004", "Test School 4", x => x.Primary()),
+            Build.Establishment("100002", "Thoresby Primary School", x => x.Primary()),
+            Build.Establishment("100003", "Manor Park Primary Academy", x => x.Primary()),
+            Build.Establishment("100004", "Montem Academy", x => x.Primary()),
             Build.Establishment("100005", "Test School 5", x => x.Primary()));
 
         Fixture.SimilarSchoolsPrimaryRepository.SetupGroups(
@@ -903,9 +903,9 @@ public class Ks2PerformanceMeasuresPageIntegrationTests(
 
         Fixture.Ks2PerformanceRepository.SetupEstablishmentPerformance(
             Build.Ks2Performance.Establishment("100001", x => x.WithGpsHigher(current: "18", prev: "17", prev2: "16")),
-            Build.Ks2Performance.Establishment("100002", x => x.WithGpsHigher(current: "24", prev: "23", prev2: "22")),
-            Build.Ks2Performance.Establishment("100003", x => x.WithGpsHigher(current: "24", prev: "22", prev2: "21")),
-            Build.Ks2Performance.Establishment("100004", x => x.WithGpsHigher(current: "23", prev: "21", prev2: "20")),
+            Build.Ks2Performance.Establishment("100002", x => x.WithGpsHigher(current: "96.6", prev: "23", prev2: "22")),
+            Build.Ks2Performance.Establishment("100003", x => x.WithGpsHigher(current: "96.5", prev: "22", prev2: "21")),
+            Build.Ks2Performance.Establishment("100004", x => x.WithGpsHigher(current: "91.4", prev: "21", prev2: "20")),
             Build.Ks2Performance.Establishment("100005", x => x.WithGpsHigher(current: "19", prev: "18", prev2: "17")));
 
         var page = await Fixture.RequestPageAsync(Routes.PrimarySchool("100001").KS2, HttpStatusCode.OK);
@@ -914,9 +914,9 @@ public class Ks2PerformanceMeasuresPageIntegrationTests(
 
         table.ShouldHaveRows(
             ["Rank", "School", "2024 to 2025"],
-            ["1", "Test School 2", "24%"],
-            ["2", "Test School 3", "24%"],
-            ["3", "Test School 4", "23%"]);
+            ["1", "Manor Park Primary Academy", "97%"],
+            ["2", "Thoresby Primary School", "97%"],
+            ["3", "Montem Academy", "91%"]);
     }
 
     [Fact]

--- a/Tests/SAPSec.Test.Integration/Tests/Primary/Ks2PerformanceMeasuresPageIntegrationTests.cs
+++ b/Tests/SAPSec.Test.Integration/Tests/Primary/Ks2PerformanceMeasuresPageIntegrationTests.cs
@@ -619,6 +619,50 @@ public class Ks2PerformanceMeasuresPageIntegrationTests(
     }
 
     [Fact]
+    public async Task AverageScaledScoreCharts_ShouldStartAxisAt80()
+    {
+        Fixture.EstablishmentRepository.SetupEstablishments(
+            Build.Establishment("100001", "Test School 1", x => x.Open().Primary().InLA("001")),
+            Build.Establishment("100002", "Test School 2", x => x.Open().Primary().InLA("002")),
+            Build.Establishment("100003", "Test School 3", x => x.Open().Primary().InLA("003")));
+
+        Fixture.SimilarSchoolsPrimaryRepository.SetupGroups(
+            Build.PrimaryGroup("100001", ["100002", "100003"]));
+
+        Fixture.Ks2PerformanceRepository.SetupEnglandPerformance(
+            Build.Ks2Performance.England(x => x
+                .WithReadingScaledScore(current: "108.4", prev: "107.6", prev2: "106.8")
+                .WithMathsScaledScore(current: "108.4", prev: "107.6", prev2: "106.8")));
+
+        Fixture.Ks2PerformanceRepository.SetupLAPerformance(
+            Build.Ks2Performance.LA("001", x => x
+                .WithReadingScaledScore(current: "105.5", prev: "104.5", prev2: "103.5")
+                .WithMathsScaledScore(current: "105.5", prev: "104.5", prev2: "103.5")));
+
+        Fixture.Ks2PerformanceRepository.SetupEstablishmentPerformance(
+            Build.Ks2Performance.Establishment("100001", x => x
+                .WithReadingScaledScore(current: "102.4", prev: "101.4", prev2: "100.4")
+                .WithMathsScaledScore(current: "102.4", prev: "101.4", prev2: "100.4")),
+            Build.Ks2Performance.Establishment("100002", x => x
+                .WithReadingScaledScore(current: "104.2", prev: "103.2", prev2: "102.2")
+                .WithMathsScaledScore(current: "104.2", prev: "103.2", prev2: "102.2")),
+            Build.Ks2Performance.Establishment("100003", x => x
+                .WithReadingScaledScore(current: "106.2", prev: "105.2", prev2: "104.2")
+                .WithMathsScaledScore(current: "106.2", prev: "105.2", prev2: "104.2")));
+
+        var page = await Fixture.RequestPageAsync(Routes.PrimarySchool("100001").KS2, HttpStatusCode.OK);
+
+        foreach (var chartId in new[] { "reading-score-school-chart", "maths-score-school-chart" })
+        {
+            var chart = page.QuerySelector($"#{chartId}");
+            chart.Should().NotBeNull();
+            chart.GetAttribute("data-axis-min").Should().Be("80");
+            chart.GetAttribute("data-axis-step").Should().Be("5");
+            chart.GetAttribute("data-axis-max").Should().Be("120");
+        }
+    }
+
+    [Fact]
     public async Task AverageScaledScoreMaths_TopPerformers_ShouldShowCorrectValues()
     {
         Fixture.EstablishmentRepository.SetupEstablishments(

--- a/terraform/application/config/review.yml
+++ b/terraform/application/config/review.yml
@@ -1,4 +1,4 @@
 ---
 ASPNETCORE_ENVIRONMENT: "Development"
 FeatureManagement__EnablePrimarySchools: "true"
-reset_review_db: "false"
+reset_review_db: "true"

--- a/terraform/application/config/review.yml
+++ b/terraform/application/config/review.yml
@@ -1,4 +1,4 @@
 ---
 ASPNETCORE_ENVIRONMENT: "Development"
 FeatureManagement__EnablePrimarySchools: "true"
-reset_review_db: "true"
+reset_review_db: "false"


### PR DESCRIPTION
## Description

Updates the KS2 primary performance page by refreshing the scaled score and GPS explanatory text, correcting scaled score chart axes and label positioning, and fixing top performer ordering when displayed values tie. Adds test coverage for the updated chart and ranking behaviour.

## Related Trello Ticket

https://trello.com/c/E1Us7jPo

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Unit tests added/updated 
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] Tested on [Environment: Dev/Staging/Local]

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have verified accessibility requirements are met


## Screenshots (if applicable)
<img width="2109" height="7153" alt="image" src="https://github.com/user-attachments/assets/74d27e0c-337c-421b-9070-3772a97aa351" />
