### PR TITLE
add k2 average reading

### DIFF
--- a/SAPSec.Core/Features/Primary/GetSchoolKs2PerformanceComparisonUseCase.cs
+++ b/SAPSec.Core/Features/Primary/GetSchoolKs2PerformanceComparisonUseCase.cs
@@ -32,6 +32,11 @@ public class GetSchoolKs2PerformanceComparisonUseCase(
                 currentSchoolData,
                 similarSchoolData,
                 [],
+                filterBy),
+            Ks2PerformanceMeasures.AverageScaledScoreReading.ForSchoolComparison(
+                currentSchoolData,
+                similarSchoolData,
+                [],
                 filterBy));
     }
 }
@@ -43,4 +48,5 @@ public record GetSchoolKs2PerformanceComparisonRequest(
 
 public record GetSchoolKs2PerformanceComparisonResponse(
     Measure MeetingExpectedStandardRwm,
-    Measure AchievedHigherStandardRwm);
+    Measure AchievedHigherStandardRwm,
+    Measure AverageScaledScoreReading);

--- a/SAPSec.Core/Features/Primary/GetSchoolKs2PerformanceComparisonUseCase.cs
+++ b/SAPSec.Core/Features/Primary/GetSchoolKs2PerformanceComparisonUseCase.cs
@@ -37,6 +37,21 @@ public class GetSchoolKs2PerformanceComparisonUseCase(
                 currentSchoolData,
                 similarSchoolData,
                 [],
+                filterBy),
+            Ks2PerformanceMeasures.AverageScaledScoreMaths.ForSchoolComparison(
+                currentSchoolData,
+                similarSchoolData,
+                [],
+                filterBy),
+            Ks2PerformanceMeasures.MeetingExpectedStandardGps.ForSchoolComparison(
+                currentSchoolData,
+                similarSchoolData,
+                [],
+                filterBy),
+            Ks2PerformanceMeasures.AchievedHigherStandardGps.ForSchoolComparison(
+                currentSchoolData,
+                similarSchoolData,
+                [],
                 filterBy));
     }
 }
@@ -49,4 +64,7 @@ public record GetSchoolKs2PerformanceComparisonRequest(
 public record GetSchoolKs2PerformanceComparisonResponse(
     Measure MeetingExpectedStandardRwm,
     Measure AchievedHigherStandardRwm,
-    Measure AverageScaledScoreReading);
+    Measure AverageScaledScoreReading,
+    Measure AverageScaledScoreMaths,
+    Measure MeetingExpectedStandardGps,
+    Measure AchievedHigherStandardGps);

--- a/SAPSec.Web/Areas/Primary/Controllers/SimilarSchoolsComparisonController.cs
+++ b/SAPSec.Web/Areas/Primary/Controllers/SimilarSchoolsComparisonController.cs
@@ -52,6 +52,12 @@ public class SimilarSchoolsComparisonController(
             comparisonResponse.AchievedHigherStandardRwm, currentSchool, similarSchool);
         model.AverageScaledScoreReading = MeasureViewModel.FromMeasure(
             comparisonResponse.AverageScaledScoreReading, currentSchool, similarSchool);
+        model.AverageScaledScoreMaths = MeasureViewModel.FromMeasure(
+            comparisonResponse.AverageScaledScoreMaths, currentSchool, similarSchool);
+        model.MeetingExpectedStandardGps = MeasureViewModel.FromMeasure(
+            comparisonResponse.MeetingExpectedStandardGps, currentSchool, similarSchool);
+        model.AchievedHigherStandardGps = MeasureViewModel.FromMeasure(
+            comparisonResponse.AchievedHigherStandardGps, currentSchool, similarSchool);
 
         ViewData["ComparisonSchool"] = model;
         return View(model);

--- a/SAPSec.Web/Areas/Primary/Controllers/SimilarSchoolsComparisonController.cs
+++ b/SAPSec.Web/Areas/Primary/Controllers/SimilarSchoolsComparisonController.cs
@@ -50,6 +50,8 @@ public class SimilarSchoolsComparisonController(
             comparisonResponse.MeetingExpectedStandardRwm, currentSchool, similarSchool);
         model.AchievedHigherStandardRwm = MeasureViewModel.FromMeasure(
             comparisonResponse.AchievedHigherStandardRwm, currentSchool, similarSchool);
+        model.AverageScaledScoreReading = MeasureViewModel.FromMeasure(
+            comparisonResponse.AverageScaledScoreReading, currentSchool, similarSchool);
 
         ViewData["ComparisonSchool"] = model;
         return View(model);

--- a/SAPSec.Web/Areas/Primary/ViewModels/PrimarySimilarSchoolsComparisonViewModel.cs
+++ b/SAPSec.Web/Areas/Primary/ViewModels/PrimarySimilarSchoolsComparisonViewModel.cs
@@ -10,4 +10,5 @@ public class PrimarySimilarSchoolsComparisonViewModel
     public required string SimilarSchoolName { get; set; }
     public MeasureViewModel? MeetingExpectedStandardRwm { get; set; }
     public MeasureViewModel? AchievedHigherStandardRwm { get; set; }
+    public MeasureViewModel? AverageScaledScoreReading { get; set; }
 }

--- a/SAPSec.Web/Areas/Primary/ViewModels/PrimarySimilarSchoolsComparisonViewModel.cs
+++ b/SAPSec.Web/Areas/Primary/ViewModels/PrimarySimilarSchoolsComparisonViewModel.cs
@@ -11,4 +11,7 @@ public class PrimarySimilarSchoolsComparisonViewModel
     public MeasureViewModel? MeetingExpectedStandardRwm { get; set; }
     public MeasureViewModel? AchievedHigherStandardRwm { get; set; }
     public MeasureViewModel? AverageScaledScoreReading { get; set; }
+    public MeasureViewModel? AverageScaledScoreMaths { get; set; }
+    public MeasureViewModel? MeetingExpectedStandardGps { get; set; }
+    public MeasureViewModel? AchievedHigherStandardGps { get; set; }
 }

--- a/SAPSec.Web/Areas/Primary/Views/SimilarSchoolsComparison/Ks2.cshtml
+++ b/SAPSec.Web/Areas/Primary/Views/SimilarSchoolsComparison/Ks2.cshtml
@@ -59,8 +59,11 @@
             </summary>
             <div class="govuk-details__text">
                 <p class="govuk-body-s govuk-!-margin-bottom-2">
-                    This shows the average reading scaled score for pupils at the end of key stage 2.
-                    Scaled scores typically range from 80 to 120, and a score of 100 represents the expected standard.
+                    This score shows how well pupils performed in the key stage 2 reading test. It is the
+                    mean scaled score of all pupils who took the test and achieved a scaled score.
+                </p>
+                <p class="govuk-body-s govuk-!-margin-bottom-2">
+                    The expected standard is 100 or more. The higher standard is 110 or more.
                 </p>
             </div>
         </details>
@@ -77,8 +80,11 @@
             </summary>
             <div class="govuk-details__text">
                 <p class="govuk-body-s govuk-!-margin-bottom-2">
-                    This shows the average maths scaled score for pupils at the end of key stage 2.
-                    Scaled scores typically range from 80 to 120, and a score of 100 represents the expected standard.
+                    This score shows how well pupils performed in the key stage 2 maths test. It is the mean
+                    scaled score of all pupils who took the test and achieved a scaled score.
+                </p>
+                <p class="govuk-body-s govuk-!-margin-bottom-2">
+                    The expected standard is 100 or more. The higher standard is 110 or more.
                 </p>
             </div>
         </details>
@@ -96,7 +102,7 @@
             <div class="govuk-details__text">
                 <p class="govuk-body-s govuk-!-margin-bottom-2">
                     Pupils achieve the expected standard when they achieve a scaled score of 100 or more
-                    in the grammar, punctuation and spelling test.
+                    in their key stage 2 grammar, punctuation and spelling test.
                 </p>
             </div>
         </details>
@@ -114,7 +120,7 @@
             <div class="govuk-details__text">
                 <p class="govuk-body-s govuk-!-margin-bottom-2">
                     Pupils achieve the higher standard when they achieve a scaled score of 110 or more
-                    in the grammar, punctuation and spelling test.
+                    in their key stage 2 grammar, punctuation and spelling test.
                 </p>
             </div>
         </details>

--- a/SAPSec.Web/Areas/Primary/Views/SimilarSchoolsComparison/Ks2.cshtml
+++ b/SAPSec.Web/Areas/Primary/Views/SimilarSchoolsComparison/Ks2.cshtml
@@ -67,6 +67,60 @@
 
         <partial name="Measures/_Measure" model=@Model.AverageScaledScoreReading />
     </section>
+
+    <section class="app-measure-section" aria-labelledby="maths-score-heading">
+        <h2 class="govuk-heading-m" id="maths-score-heading" data-testid="maths-score-heading">@Model.AverageScaledScoreMaths!.MeasureInfo.Name</h2>
+
+        <details class="govuk-details app-measure-details" data-module="govuk-details">
+            <summary class="govuk-details__summary">
+                <span class="govuk-details__summary-text">Information about average scaled score in maths</span>
+            </summary>
+            <div class="govuk-details__text">
+                <p class="govuk-body-s govuk-!-margin-bottom-2">
+                    This shows the average maths scaled score for pupils at the end of key stage 2.
+                    Scaled scores typically range from 80 to 120, and a score of 100 represents the expected standard.
+                </p>
+            </div>
+        </details>
+
+        <partial name="Measures/_Measure" model=@Model.AverageScaledScoreMaths />
+    </section>
+
+    <section class="app-measure-section" aria-labelledby="expected-gps-heading">
+        <h2 class="govuk-heading-m" id="expected-gps-heading" data-testid="expected-gps-heading">@Model.MeetingExpectedStandardGps!.MeasureInfo.Name</h2>
+
+        <details class="govuk-details app-measure-details" data-module="govuk-details">
+            <summary class="govuk-details__summary">
+                <span class="govuk-details__summary-text">Information about meeting the expected standard</span>
+            </summary>
+            <div class="govuk-details__text">
+                <p class="govuk-body-s govuk-!-margin-bottom-2">
+                    Pupils achieve the expected standard when they achieve a scaled score of 100 or more
+                    in the grammar, punctuation and spelling test.
+                </p>
+            </div>
+        </details>
+
+        <partial name="Measures/_Measure" model=@Model.MeetingExpectedStandardGps />
+    </section>
+
+    <section class="app-measure-section" aria-labelledby="higher-gps-heading">
+        <h2 class="govuk-heading-m" id="higher-gps-heading" data-testid="higher-gps-heading">@Model.AchievedHigherStandardGps!.MeasureInfo.Name</h2>
+
+        <details class="govuk-details app-measure-details" data-module="govuk-details">
+            <summary class="govuk-details__summary">
+                <span class="govuk-details__summary-text">Information about achieving the higher standard</span>
+            </summary>
+            <div class="govuk-details__text">
+                <p class="govuk-body-s govuk-!-margin-bottom-2">
+                    Pupils achieve the higher standard when they achieve a scaled score of 110 or more
+                    in the grammar, punctuation and spelling test.
+                </p>
+            </div>
+        </details>
+
+        <partial name="Measures/_Measure" model=@Model.AchievedHigherStandardGps />
+    </section>
 </form>
 
 @section Scripts {

--- a/SAPSec.Web/Areas/Primary/Views/SimilarSchoolsComparison/Ks2.cshtml
+++ b/SAPSec.Web/Areas/Primary/Views/SimilarSchoolsComparison/Ks2.cshtml
@@ -49,6 +49,24 @@
 
         <partial name="Measures/_Measure" model=@Model.AchievedHigherStandardRwm />
     </section>
+
+    <section class="app-measure-section" aria-labelledby="reading-score-heading">
+        <h2 class="govuk-heading-m" id="reading-score-heading" data-testid="reading-score-heading">@Model.AverageScaledScoreReading!.MeasureInfo.Name</h2>
+
+        <details class="govuk-details app-measure-details" data-module="govuk-details">
+            <summary class="govuk-details__summary">
+                <span class="govuk-details__summary-text">Information about average scaled score in reading</span>
+            </summary>
+            <div class="govuk-details__text">
+                <p class="govuk-body-s govuk-!-margin-bottom-2">
+                    This shows the average reading scaled score for pupils at the end of key stage 2.
+                    Scaled scores typically range from 80 to 120, and a score of 100 represents the expected standard.
+                </p>
+            </div>
+        </details>
+
+        <partial name="Measures/_Measure" model=@Model.AverageScaledScoreReading />
+    </section>
 </form>
 
 @section Scripts {

--- a/SAPSec.Web/AssetSrc/js/chart-factory.js
+++ b/SAPSec.Web/AssetSrc/js/chart-factory.js
@@ -325,6 +325,19 @@ function getDynamicLineAxisConfig(chartData, axisSuffix) {
     };
 }
 
+function toFixedRoundedHalfAwayFromZero(value, decimals) {
+    // Number.prototype.toFixed rounds based on the binary floating-point
+    // representation of `value`, which can differ from the decimal value's
+    // true nearest/rounded representation (e.g. (98.05).toFixed(1) === "98.0").
+    // Rounding the absolute value (nudged by Number.EPSILON to correct for
+    // float imprecision) and reapplying the sign matches the server-side
+    // decimal rounding used for the table (0.0-style, half away from zero).
+    const factor = Math.pow(10, decimals);
+    const sign = value < 0 ? -1 : 1;
+    const rounded = sign * Math.round((Math.abs(value) + Number.EPSILON) * factor) / factor;
+    return rounded.toFixed(decimals);
+}
+
 function formatTooltipValue(value, axisSuffix, decimals) {
     if (value === null || value === undefined || Number.isNaN(Number(value))) {
         return 'No data';
@@ -332,7 +345,7 @@ function formatTooltipValue(value, axisSuffix, decimals) {
 
     const numericValue = Number(value);
     const formattedValue = decimals !== null && decimals !== undefined
-        ? numericValue.toFixed(decimals)
+        ? toFixedRoundedHalfAwayFromZero(numericValue, decimals)
         : numericValue;
 
     return `${formattedValue}${axisSuffix}`;
@@ -891,7 +904,7 @@ function initCharts(canvas) {
                 if (!showDataLabels || value === null || value === undefined || Number.isNaN(value)) {
                     return null;
                 }
-                return `${Number(value).toFixed(labelDecimals)}${axisSuffix}`;
+                return `${toFixedRoundedHalfAwayFromZero(Number(value), labelDecimals)}${axisSuffix}`;
             };
         }
 

--- a/SAPSec.Web/ViewModels/Measures/MeasureViewModel.cs
+++ b/SAPSec.Web/ViewModels/Measures/MeasureViewModel.cs
@@ -23,19 +23,28 @@ public record MeasureViewModel(
             _ => throw new InvalidOperationException($"No label found for Measure Series Type: {Enum.GetName(seriesType)}")
         };
 
+    // chart-factory.js assigns bar/line colours to datasets by array position (school/similarSchools/
+    // localAuthority/england), which assumes the 4-series shape produced by Measure.ForSchool. The 3-series
+    // comparison shape (CurrentSchool/SimilarSchool/EnglandSchoolsAverage) puts England at the position
+    // chart-factory.js treats as "local authority", so comparison charts must supply explicit colours.
+    private static readonly string[] ComparisonChartColors = ["#ca357c", "#2a1950", "#2a1950"];
+    private static readonly string[] ComparisonYearByYearColors = ["#ca357c", "#2a1950", "#4b9b7d"];
+
     public static MeasureViewModel FromMeasure(
         Measure measure,
         SchoolInfo schoolInfo,
         SchoolInfo? similarSchool = null)
     {
+        var isComparison = similarSchool is not null;
+
         var measureInfo = new MeasureInfoViewModel(
             measure.Key,
             measure.Name,
             measure.DataType,
             measure.Filters.Select(MapAvailableFilter),
             measure.Series.Select(s => ResolveSeriesLabel(s.SeriesType, schoolInfo, similarSchool)),
-            null,
-            null);
+            isComparison ? ComparisonChartColors : null,
+            isComparison ? ComparisonYearByYearColors : null);
 
         decimal? MapCurrentYear(MeasureSeries series) =>
             series.Current;

--- a/Tests/SAPSec.Core.Tests/Features/Primary/GetSchoolKs2PerformanceComparisonUseCaseTests.cs
+++ b/Tests/SAPSec.Core.Tests/Features/Primary/GetSchoolKs2PerformanceComparisonUseCaseTests.cs
@@ -316,6 +316,183 @@ public class GetSchoolKs2PerformanceComparisonUseCaseTests
     }
 
     [Fact]
+    public async Task AverageScaledScoreMaths_ShouldContainExpectedMeasureSeries()
+    {
+        _establishmentRepo.SetupEstablishments(
+            Build.Establishment("100001", "Test School 1", x => x.Primary()),
+            Build.Establishment("100002", "Test School 2", x => x.Primary()));
+
+        var response = await _sut.Execute(Request("100001", "100002"));
+
+        var seriesTypes = response.AverageScaledScoreMaths.Series.Select(s => s.SeriesType);
+
+        seriesTypes.Should().BeEquivalentTo([
+            MeasureSeriesType.CurrentSchool,
+            MeasureSeriesType.SimilarSchool,
+            MeasureSeriesType.EnglandSchoolsAverage
+        ]);
+    }
+
+    [Fact]
+    public async Task AverageScaledScoreMaths_ContainsYearByYearValuesForCurrentAndSimilarSchool()
+    {
+        _establishmentRepo.SetupEstablishments(
+            Build.Establishment("100001", "Test School 1", x => x.Primary()),
+            Build.Establishment("100002", "Test School 2", x => x.Primary()));
+
+        _performanceRepo.SetupEstablishmentPerformance(
+            Build.Ks2Performance.Establishment("100001", x => x.WithMathsScaledScore(current: "102.4", prev: "101.4", prev2: "100.4")),
+            Build.Ks2Performance.Establishment("100002", x => x.WithMathsScaledScore(current: "104.2", prev: "103.2", prev2: "102.2")));
+
+        _performanceRepo.SetupEnglandPerformance(
+            Build.Ks2Performance.England(x => x.WithMathsScaledScore(current: "108.4", prev: "107.6", prev2: "106.8")));
+
+        var response = await _sut.Execute(Request("100001", "100002"));
+        var series = response.AverageScaledScoreMaths.Series;
+
+        series.Should().BeEquivalentTo([
+            new MeasureSeries(MeasureSeriesType.CurrentSchool, 102.4m, 101.4m, 100.4m),
+            new MeasureSeries(MeasureSeriesType.SimilarSchool, 104.2m, 103.2m, 102.2m),
+            new MeasureSeries(MeasureSeriesType.EnglandSchoolsAverage, 108.4m, 107.6m, 106.8m)
+        ]);
+    }
+
+    [Fact]
+    public async Task AverageScaledScoreMaths_WhenNoPerformanceDataForSimilarSchool_ContainsNullValues()
+    {
+        _establishmentRepo.SetupEstablishments(
+            Build.Establishment("100001", "Test School 1", x => x.Primary()),
+            Build.Establishment("100002", "Test School 2", x => x.Primary()));
+
+        _performanceRepo.SetupEstablishmentPerformance(
+            Build.Ks2Performance.Establishment("100001", x => x.WithMathsScaledScore(current: "102.4", prev: "101.4", prev2: "100.4")));
+
+        var response = await _sut.Execute(Request("100001", "100002"));
+        var series = response.AverageScaledScoreMaths.Series
+            .First(s => s.SeriesType == MeasureSeriesType.SimilarSchool);
+
+        series.Should().Be(new MeasureSeries(MeasureSeriesType.SimilarSchool, null, null, null));
+    }
+
+    [Fact]
+    public async Task MeetingExpectedStandardGps_ShouldContainExpectedMeasureSeries()
+    {
+        _establishmentRepo.SetupEstablishments(
+            Build.Establishment("100001", "Test School 1", x => x.Primary()),
+            Build.Establishment("100002", "Test School 2", x => x.Primary()));
+
+        var response = await _sut.Execute(Request("100001", "100002"));
+
+        var seriesTypes = response.MeetingExpectedStandardGps.Series.Select(s => s.SeriesType);
+
+        seriesTypes.Should().BeEquivalentTo([
+            MeasureSeriesType.CurrentSchool,
+            MeasureSeriesType.SimilarSchool,
+            MeasureSeriesType.EnglandSchoolsAverage
+        ]);
+    }
+
+    [Fact]
+    public async Task MeetingExpectedStandardGps_ContainsYearByYearValuesForCurrentAndSimilarSchool()
+    {
+        _establishmentRepo.SetupEstablishments(
+            Build.Establishment("100001", "Test School 1", x => x.Primary()),
+            Build.Establishment("100002", "Test School 2", x => x.Primary()));
+
+        _performanceRepo.SetupEstablishmentPerformance(
+            Build.Ks2Performance.Establishment("100001", x => x.WithGpsExpected(current: "62", prev: "61", prev2: "60")),
+            Build.Ks2Performance.Establishment("100002", x => x.WithGpsExpected(current: "77", prev: "76", prev2: "75")));
+
+        _performanceRepo.SetupEnglandPerformance(
+            Build.Ks2Performance.England(x => x.WithGpsExpected(current: "69", prev: "68", prev2: "67")));
+
+        var response = await _sut.Execute(Request("100001", "100002"));
+        var series = response.MeetingExpectedStandardGps.Series;
+
+        series.Should().BeEquivalentTo([
+            new MeasureSeries(MeasureSeriesType.CurrentSchool, 62m, 61m, 60m),
+            new MeasureSeries(MeasureSeriesType.SimilarSchool, 77m, 76m, 75m),
+            new MeasureSeries(MeasureSeriesType.EnglandSchoolsAverage, 69m, 68m, 67m)
+        ]);
+    }
+
+    [Fact]
+    public async Task MeetingExpectedStandardGps_WhenNoPerformanceDataForSimilarSchool_ContainsNullValues()
+    {
+        _establishmentRepo.SetupEstablishments(
+            Build.Establishment("100001", "Test School 1", x => x.Primary()),
+            Build.Establishment("100002", "Test School 2", x => x.Primary()));
+
+        _performanceRepo.SetupEstablishmentPerformance(
+            Build.Ks2Performance.Establishment("100001", x => x.WithGpsExpected(current: "62", prev: "61", prev2: "60")));
+
+        var response = await _sut.Execute(Request("100001", "100002"));
+        var series = response.MeetingExpectedStandardGps.Series
+            .First(s => s.SeriesType == MeasureSeriesType.SimilarSchool);
+
+        series.Should().Be(new MeasureSeries(MeasureSeriesType.SimilarSchool, null, null, null));
+    }
+
+    [Fact]
+    public async Task AchievedHigherStandardGps_ShouldContainExpectedMeasureSeries()
+    {
+        _establishmentRepo.SetupEstablishments(
+            Build.Establishment("100001", "Test School 1", x => x.Primary()),
+            Build.Establishment("100002", "Test School 2", x => x.Primary()));
+
+        var response = await _sut.Execute(Request("100001", "100002"));
+
+        var seriesTypes = response.AchievedHigherStandardGps.Series.Select(s => s.SeriesType);
+
+        seriesTypes.Should().BeEquivalentTo([
+            MeasureSeriesType.CurrentSchool,
+            MeasureSeriesType.SimilarSchool,
+            MeasureSeriesType.EnglandSchoolsAverage
+        ]);
+    }
+
+    [Fact]
+    public async Task AchievedHigherStandardGps_ContainsYearByYearValuesForCurrentAndSimilarSchool()
+    {
+        _establishmentRepo.SetupEstablishments(
+            Build.Establishment("100001", "Test School 1", x => x.Primary()),
+            Build.Establishment("100002", "Test School 2", x => x.Primary()));
+
+        _performanceRepo.SetupEstablishmentPerformance(
+            Build.Ks2Performance.Establishment("100001", x => x.WithGpsHigher(current: "18", prev: "17", prev2: "16")),
+            Build.Ks2Performance.Establishment("100002", x => x.WithGpsHigher(current: "24", prev: "23", prev2: "22")));
+
+        _performanceRepo.SetupEnglandPerformance(
+            Build.Ks2Performance.England(x => x.WithGpsHigher(current: "15", prev: "14", prev2: "13")));
+
+        var response = await _sut.Execute(Request("100001", "100002"));
+        var series = response.AchievedHigherStandardGps.Series;
+
+        series.Should().BeEquivalentTo([
+            new MeasureSeries(MeasureSeriesType.CurrentSchool, 18m, 17m, 16m),
+            new MeasureSeries(MeasureSeriesType.SimilarSchool, 24m, 23m, 22m),
+            new MeasureSeries(MeasureSeriesType.EnglandSchoolsAverage, 15m, 14m, 13m)
+        ]);
+    }
+
+    [Fact]
+    public async Task AchievedHigherStandardGps_WhenNoPerformanceDataForSimilarSchool_ContainsNullValues()
+    {
+        _establishmentRepo.SetupEstablishments(
+            Build.Establishment("100001", "Test School 1", x => x.Primary()),
+            Build.Establishment("100002", "Test School 2", x => x.Primary()));
+
+        _performanceRepo.SetupEstablishmentPerformance(
+            Build.Ks2Performance.Establishment("100001", x => x.WithGpsHigher(current: "18", prev: "17", prev2: "16")));
+
+        var response = await _sut.Execute(Request("100001", "100002"));
+        var series = response.AchievedHigherStandardGps.Series
+            .First(s => s.SeriesType == MeasureSeriesType.SimilarSchool);
+
+        series.Should().Be(new MeasureSeries(MeasureSeriesType.SimilarSchool, null, null, null));
+    }
+
+    [Fact]
     public async Task FilterBy_ForOneMeasure_DoesNotAffectTheOther()
     {
         _establishmentRepo.SetupEstablishments(

--- a/Tests/SAPSec.Core.Tests/Features/Primary/GetSchoolKs2PerformanceComparisonUseCaseTests.cs
+++ b/Tests/SAPSec.Core.Tests/Features/Primary/GetSchoolKs2PerformanceComparisonUseCaseTests.cs
@@ -257,6 +257,65 @@ public class GetSchoolKs2PerformanceComparisonUseCaseTests
     }
 
     [Fact]
+    public async Task AverageScaledScoreReading_ShouldContainExpectedMeasureSeries()
+    {
+        _establishmentRepo.SetupEstablishments(
+            Build.Establishment("100001", "Test School 1", x => x.Primary()),
+            Build.Establishment("100002", "Test School 2", x => x.Primary()));
+
+        var response = await _sut.Execute(Request("100001", "100002"));
+
+        var seriesTypes = response.AverageScaledScoreReading.Series.Select(s => s.SeriesType);
+
+        seriesTypes.Should().BeEquivalentTo([
+            MeasureSeriesType.CurrentSchool,
+            MeasureSeriesType.SimilarSchool,
+            MeasureSeriesType.EnglandSchoolsAverage
+        ]);
+    }
+
+    [Fact]
+    public async Task AverageScaledScoreReading_ContainsYearByYearValuesForCurrentAndSimilarSchool()
+    {
+        _establishmentRepo.SetupEstablishments(
+            Build.Establishment("100001", "Test School 1", x => x.Primary()),
+            Build.Establishment("100002", "Test School 2", x => x.Primary()));
+
+        _performanceRepo.SetupEstablishmentPerformance(
+            Build.Ks2Performance.Establishment("100001", x => x.WithReadingScaledScore(current: "101.4", prev: "100.4", prev2: "99.4")),
+            Build.Ks2Performance.Establishment("100002", x => x.WithReadingScaledScore(current: "103.2", prev: "102.2", prev2: "101.2")));
+
+        _performanceRepo.SetupEnglandPerformance(
+            Build.Ks2Performance.England(x => x.WithReadingScaledScore(current: "107.4", prev: "106.6", prev2: "105.8")));
+
+        var response = await _sut.Execute(Request("100001", "100002"));
+        var series = response.AverageScaledScoreReading.Series;
+
+        series.Should().BeEquivalentTo([
+            new MeasureSeries(MeasureSeriesType.CurrentSchool, 101.4m, 100.4m, 99.4m),
+            new MeasureSeries(MeasureSeriesType.SimilarSchool, 103.2m, 102.2m, 101.2m),
+            new MeasureSeries(MeasureSeriesType.EnglandSchoolsAverage, 107.4m, 106.6m, 105.8m)
+        ]);
+    }
+
+    [Fact]
+    public async Task AverageScaledScoreReading_WhenNoPerformanceDataForSimilarSchool_ContainsNullValues()
+    {
+        _establishmentRepo.SetupEstablishments(
+            Build.Establishment("100001", "Test School 1", x => x.Primary()),
+            Build.Establishment("100002", "Test School 2", x => x.Primary()));
+
+        _performanceRepo.SetupEstablishmentPerformance(
+            Build.Ks2Performance.Establishment("100001", x => x.WithReadingScaledScore(current: "101.4", prev: "100.4", prev2: "99.4")));
+
+        var response = await _sut.Execute(Request("100001", "100002"));
+        var series = response.AverageScaledScoreReading.Series
+            .First(s => s.SeriesType == MeasureSeriesType.SimilarSchool);
+
+        series.Should().Be(new MeasureSeries(MeasureSeriesType.SimilarSchool, null, null, null));
+    }
+
+    [Fact]
     public async Task FilterBy_ForOneMeasure_DoesNotAffectTheOther()
     {
         _establishmentRepo.SetupEstablishments(

--- a/Tests/SAPSec.Test.EndToEnd/SimilarSchoolsComparisonKs2PageEndToEndTests.cs
+++ b/Tests/SAPSec.Test.EndToEnd/SimilarSchoolsComparisonKs2PageEndToEndTests.cs
@@ -14,6 +14,7 @@ public class SimilarSchoolsComparisonKs2PageEndToEndTests(EndToEndTestsFixture f
 {
     private const string MeetingExpectedStandardHeaderText = "Meeting expected standard in reading, writing and maths";
     private const string AchievedHigherStandardHeaderText = "Achieved a higher standard in reading, writing and maths";
+    private const string ReadingScaledScoreHeaderText = "Average scaled score in reading";
 
     private const string Urn = "101206";
     private static readonly Routes.Primary PrimarySchoolRoute = Routes.PrimarySchool(Urn);
@@ -133,6 +134,49 @@ public class SimilarSchoolsComparisonKs2PageEndToEndTests(EndToEndTestsFixture f
     public async Task AchievedHigherStandardRwm_ToggleBetweenYearByYearAndCurrentYearView()
     {
         var section = await GetSection(AchievedHigherStandardHeaderText);
+
+        await section.GetByRole(AriaRole.Tab, new() { Name = "Charts" }).ClickAsync();
+
+        var currentYearHeader = section.GetByRole(AriaRole.Heading, new() { Name = "2024 to 2025" });
+        var yearByYearHeader = section.GetByRole(AriaRole.Heading, new() { Name = "Year by year" });
+
+        await Expect(currentYearHeader).ToBeVisibleAsync();
+        await Expect(yearByYearHeader).ToBeHiddenAsync();
+
+        await section.GetByRole(AriaRole.Button, new() { Name = "Show year by year" }).ClickAsync();
+
+        await Expect(currentYearHeader).ToBeHiddenAsync();
+        await Expect(yearByYearHeader).ToBeVisibleAsync();
+    }
+
+    [Fact]
+    public async Task AverageScaledScoreReading_DetailsToggle_IsCollapsedByDefaultAndExpands()
+    {
+        var section = await GetSection(ReadingScaledScoreHeaderText);
+        var details = section.Locator(".app-measure-details");
+
+        await Expect(details).Not.ToHaveAttributeAsync("open", "");
+        await details.Locator("summary").ClickAsync();
+        await Expect(details).ToHaveAttributeAsync("open", "");
+    }
+
+    [Fact]
+    public async Task AverageScaledScoreReading_ViewTableView()
+    {
+        var section = await GetSection(ReadingScaledScoreHeaderText);
+        await section.GetByRole(AriaRole.Tab, new() { Name = "Table" }).ClickAsync();
+
+        var table = section.GetByRole(AriaRole.Table);
+        await Expect(table).ToBeVisibleAsync();
+
+        var schools = await table.GetTableColumnAsync("School(s)");
+        await Expect(schools).ToHaveCountAsync(3);
+    }
+
+    [Fact]
+    public async Task AverageScaledScoreReading_ToggleBetweenYearByYearAndCurrentYearView()
+    {
+        var section = await GetSection(ReadingScaledScoreHeaderText);
 
         await section.GetByRole(AriaRole.Tab, new() { Name = "Charts" }).ClickAsync();
 

--- a/Tests/SAPSec.Test.EndToEnd/SimilarSchoolsComparisonKs2PageEndToEndTests.cs
+++ b/Tests/SAPSec.Test.EndToEnd/SimilarSchoolsComparisonKs2PageEndToEndTests.cs
@@ -15,6 +15,9 @@ public class SimilarSchoolsComparisonKs2PageEndToEndTests(EndToEndTestsFixture f
     private const string MeetingExpectedStandardHeaderText = "Meeting expected standard in reading, writing and maths";
     private const string AchievedHigherStandardHeaderText = "Achieved a higher standard in reading, writing and maths";
     private const string ReadingScaledScoreHeaderText = "Average scaled score in reading";
+    private const string MathsScaledScoreHeaderText = "Average scaled score in maths";
+    private const string MeetingExpectedStandardGpsHeaderText = "Meeting expected standard in grammar, punctuation and spelling";
+    private const string AchievedHigherStandardGpsHeaderText = "Achieved a higher standard in grammar, punctuation and spelling";
 
     private const string Urn = "101206";
     private static readonly Routes.Primary PrimarySchoolRoute = Routes.PrimarySchool(Urn);
@@ -177,6 +180,135 @@ public class SimilarSchoolsComparisonKs2PageEndToEndTests(EndToEndTestsFixture f
     public async Task AverageScaledScoreReading_ToggleBetweenYearByYearAndCurrentYearView()
     {
         var section = await GetSection(ReadingScaledScoreHeaderText);
+
+        await section.GetByRole(AriaRole.Tab, new() { Name = "Charts" }).ClickAsync();
+
+        var currentYearHeader = section.GetByRole(AriaRole.Heading, new() { Name = "2024 to 2025" });
+        var yearByYearHeader = section.GetByRole(AriaRole.Heading, new() { Name = "Year by year" });
+
+        await Expect(currentYearHeader).ToBeVisibleAsync();
+        await Expect(yearByYearHeader).ToBeHiddenAsync();
+
+        await section.GetByRole(AriaRole.Button, new() { Name = "Show year by year" }).ClickAsync();
+
+        await Expect(currentYearHeader).ToBeHiddenAsync();
+        await Expect(yearByYearHeader).ToBeVisibleAsync();
+    }
+
+    [Fact]
+    public async Task AverageScaledScoreMaths_DetailsToggle_IsCollapsedByDefaultAndExpands()
+    {
+        var section = await GetSection(MathsScaledScoreHeaderText);
+        var details = section.Locator(".app-measure-details");
+
+        await Expect(details).Not.ToHaveAttributeAsync("open", "");
+        await details.Locator("summary").ClickAsync();
+        await Expect(details).ToHaveAttributeAsync("open", "");
+    }
+
+    [Fact]
+    public async Task AverageScaledScoreMaths_ViewTableView()
+    {
+        var section = await GetSection(MathsScaledScoreHeaderText);
+        await section.GetByRole(AriaRole.Tab, new() { Name = "Table" }).ClickAsync();
+
+        var table = section.GetByRole(AriaRole.Table);
+        await Expect(table).ToBeVisibleAsync();
+
+        var schools = await table.GetTableColumnAsync("School(s)");
+        await Expect(schools).ToHaveCountAsync(3);
+    }
+
+    [Fact]
+    public async Task AverageScaledScoreMaths_ToggleBetweenYearByYearAndCurrentYearView()
+    {
+        var section = await GetSection(MathsScaledScoreHeaderText);
+
+        await section.GetByRole(AriaRole.Tab, new() { Name = "Charts" }).ClickAsync();
+
+        var currentYearHeader = section.GetByRole(AriaRole.Heading, new() { Name = "2024 to 2025" });
+        var yearByYearHeader = section.GetByRole(AriaRole.Heading, new() { Name = "Year by year" });
+
+        await Expect(currentYearHeader).ToBeVisibleAsync();
+        await Expect(yearByYearHeader).ToBeHiddenAsync();
+
+        await section.GetByRole(AriaRole.Button, new() { Name = "Show year by year" }).ClickAsync();
+
+        await Expect(currentYearHeader).ToBeHiddenAsync();
+        await Expect(yearByYearHeader).ToBeVisibleAsync();
+    }
+
+    [Fact]
+    public async Task MeetingExpectedStandardGps_DetailsToggle_IsCollapsedByDefaultAndExpands()
+    {
+        var section = await GetSection(MeetingExpectedStandardGpsHeaderText);
+        var details = section.Locator(".app-measure-details");
+
+        await Expect(details).Not.ToHaveAttributeAsync("open", "");
+        await details.Locator("summary").ClickAsync();
+        await Expect(details).ToHaveAttributeAsync("open", "");
+    }
+
+    [Fact]
+    public async Task MeetingExpectedStandardGps_ViewTableView()
+    {
+        var section = await GetSection(MeetingExpectedStandardGpsHeaderText);
+        await section.GetByRole(AriaRole.Tab, new() { Name = "Table" }).ClickAsync();
+
+        var table = section.GetByRole(AriaRole.Table);
+        await Expect(table).ToBeVisibleAsync();
+
+        var schools = await table.GetTableColumnAsync("School(s)");
+        await Expect(schools).ToHaveCountAsync(3);
+    }
+
+    [Fact]
+    public async Task MeetingExpectedStandardGps_ToggleBetweenYearByYearAndCurrentYearView()
+    {
+        var section = await GetSection(MeetingExpectedStandardGpsHeaderText);
+
+        await section.GetByRole(AriaRole.Tab, new() { Name = "Charts" }).ClickAsync();
+
+        var currentYearHeader = section.GetByRole(AriaRole.Heading, new() { Name = "2024 to 2025" });
+        var yearByYearHeader = section.GetByRole(AriaRole.Heading, new() { Name = "Year by year" });
+
+        await Expect(currentYearHeader).ToBeVisibleAsync();
+        await Expect(yearByYearHeader).ToBeHiddenAsync();
+
+        await section.GetByRole(AriaRole.Button, new() { Name = "Show year by year" }).ClickAsync();
+
+        await Expect(currentYearHeader).ToBeHiddenAsync();
+        await Expect(yearByYearHeader).ToBeVisibleAsync();
+    }
+
+    [Fact]
+    public async Task AchievedHigherStandardGps_DetailsToggle_IsCollapsedByDefaultAndExpands()
+    {
+        var section = await GetSection(AchievedHigherStandardGpsHeaderText);
+        var details = section.Locator(".app-measure-details");
+
+        await Expect(details).Not.ToHaveAttributeAsync("open", "");
+        await details.Locator("summary").ClickAsync();
+        await Expect(details).ToHaveAttributeAsync("open", "");
+    }
+
+    [Fact]
+    public async Task AchievedHigherStandardGps_ViewTableView()
+    {
+        var section = await GetSection(AchievedHigherStandardGpsHeaderText);
+        await section.GetByRole(AriaRole.Tab, new() { Name = "Table" }).ClickAsync();
+
+        var table = section.GetByRole(AriaRole.Table);
+        await Expect(table).ToBeVisibleAsync();
+
+        var schools = await table.GetTableColumnAsync("School(s)");
+        await Expect(schools).ToHaveCountAsync(3);
+    }
+
+    [Fact]
+    public async Task AchievedHigherStandardGps_ToggleBetweenYearByYearAndCurrentYearView()
+    {
+        var section = await GetSection(AchievedHigherStandardGpsHeaderText);
 
         await section.GetByRole(AriaRole.Tab, new() { Name = "Charts" }).ClickAsync();
 

--- a/Tests/SAPSec.Test.Integration/Tests/Primary/Ks2PerformanceMeasuresPageIntegrationTests.cs
+++ b/Tests/SAPSec.Test.Integration/Tests/Primary/Ks2PerformanceMeasuresPageIntegrationTests.cs
@@ -657,7 +657,7 @@ public class Ks2PerformanceMeasuresPageIntegrationTests(
             var chart = page.QuerySelector($"#{chartId}");
             chart.Should().NotBeNull();
             chart.GetAttribute("data-axis-min").Should().Be("80");
-            chart.GetAttribute("data-axis-step").Should().Be("5");
+            chart.GetAttribute("data-axis-step").Should().Be("20");
             chart.GetAttribute("data-axis-max").Should().Be("120");
         }
     }

--- a/Tests/SAPSec.Test.Integration/Tests/Primary/SimilarSchoolsComparisonIntegrationTests.cs
+++ b/Tests/SAPSec.Test.Integration/Tests/Primary/SimilarSchoolsComparisonIntegrationTests.cs
@@ -245,4 +245,42 @@ public class SimilarSchoolsComparisonIntegrationTests(
             ["Test School 2", .. similarSchool],
             ["Schools in England average", .. england]);
     }
+
+    [Fact]
+    public async Task AverageScaledScoreReading_MeasureExistsOnPage()
+    {
+        var page = await Fixture.RequestPageAsync(
+            Routes.PrimarySchool(PrimarySchoolUrn).SimilarSchoolComparisonKs2(SimilarSchoolUrn));
+
+        var heading = page.ElementWithTestIdShouldExist("reading-score-heading");
+        heading.TrimmedTextContent().Should().Be("Average scaled score in reading");
+
+        var details = page.QuerySelectorAll("details.govuk-details")
+            .FirstOrDefault(d => d.QuerySelector(".govuk-details__summary-text")?.TrimmedTextContent()
+                == "Information about average scaled score in reading");
+        details.Should().NotBeNull();
+        details!.HasAttribute("open").Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task AverageScaledScoreReading_TableView_ShouldShowCorrectValues()
+    {
+        Fixture.Ks2PerformanceRepository.SetupEstablishmentPerformance(
+            Build.Ks2Performance.Establishment(PrimarySchoolUrn, x => x.WithReadingScaledScore(current: "101.4", prev: "100.4", prev2: "99.4")),
+            Build.Ks2Performance.Establishment(SimilarSchoolUrn, x => x.WithReadingScaledScore(current: "103.2", prev: "102.2", prev2: "101.2")));
+
+        Fixture.Ks2PerformanceRepository.SetupEnglandPerformance(
+            Build.Ks2Performance.England(x => x.WithReadingScaledScore(current: "107.4", prev: "106.6", prev2: "105.8")));
+
+        var page = await Fixture.RequestPageAsync(
+            Routes.PrimarySchool(PrimarySchoolUrn).SimilarSchoolComparisonKs2(SimilarSchoolUrn));
+
+        var table = page.ElementWithTestIdShouldExist<IHtmlTableElement>("reading-score-table-view-table");
+
+        table.ShouldHaveRows(
+            ["School(s)", "2022 to 2023", "2023 to 2024", "2024 to 2025"],
+            ["Test School 1", "99.4", "100.4", "101.4"],
+            ["Test School 2", "101.2", "102.2", "103.2"],
+            ["Schools in England average", "105.8", "106.6", "107.4"]);
+    }
 }

--- a/Tests/SAPSec.Test.Integration/Tests/Primary/SimilarSchoolsComparisonIntegrationTests.cs
+++ b/Tests/SAPSec.Test.Integration/Tests/Primary/SimilarSchoolsComparisonIntegrationTests.cs
@@ -263,6 +263,21 @@ public class SimilarSchoolsComparisonIntegrationTests(
     }
 
     [Fact]
+    public async Task MeetingExpectedStandardRwm_Charts_UseCorrectSchoolColours()
+    {
+        var page = await Fixture.RequestPageAsync(
+            Routes.PrimarySchool(PrimarySchoolUrn).SimilarSchoolComparisonKs2(SimilarSchoolUrn));
+
+        var barChart = page.QuerySelector("[id$='expected-rwm-school-chart']");
+        barChart.Should().NotBeNull();
+        barChart!.GetAttribute("data-colors").Should().Be("[\"#ca357c\",\"#2a1950\",\"#2a1950\"]");
+
+        var lineChart = page.QuerySelector("[id$='expected-rwm-school-yearbyyear-chart']");
+        lineChart.Should().NotBeNull();
+        lineChart!.GetAttribute("data-colors").Should().Be("[\"#ca357c\",\"#2a1950\",\"#4b9b7d\"]");
+    }
+
+    [Fact]
     public async Task AverageScaledScoreReading_TableView_ShouldShowCorrectValues()
     {
         Fixture.Ks2PerformanceRepository.SetupEstablishmentPerformance(

--- a/Tests/SAPSec.Test.Integration/Tests/Primary/SimilarSchoolsComparisonIntegrationTests.cs
+++ b/Tests/SAPSec.Test.Integration/Tests/Primary/SimilarSchoolsComparisonIntegrationTests.cs
@@ -283,4 +283,124 @@ public class SimilarSchoolsComparisonIntegrationTests(
             ["Test School 2", "101.2", "102.2", "103.2"],
             ["Schools in England average", "105.8", "106.6", "107.4"]);
     }
+
+    [Fact]
+    public async Task AverageScaledScoreMaths_MeasureExistsOnPage()
+    {
+        var page = await Fixture.RequestPageAsync(
+            Routes.PrimarySchool(PrimarySchoolUrn).SimilarSchoolComparisonKs2(SimilarSchoolUrn));
+
+        var heading = page.ElementWithTestIdShouldExist("maths-score-heading");
+        heading.TrimmedTextContent().Should().Be("Average scaled score in maths");
+
+        var details = page.QuerySelectorAll("details.govuk-details")
+            .FirstOrDefault(d => d.QuerySelector(".govuk-details__summary-text")?.TrimmedTextContent()
+                == "Information about average scaled score in maths");
+        details.Should().NotBeNull();
+        details!.HasAttribute("open").Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task AverageScaledScoreMaths_TableView_ShouldShowCorrectValues()
+    {
+        Fixture.Ks2PerformanceRepository.SetupEstablishmentPerformance(
+            Build.Ks2Performance.Establishment(PrimarySchoolUrn, x => x.WithMathsScaledScore(current: "102.4", prev: "101.4", prev2: "100.4")),
+            Build.Ks2Performance.Establishment(SimilarSchoolUrn, x => x.WithMathsScaledScore(current: "104.2", prev: "103.2", prev2: "102.2")));
+
+        Fixture.Ks2PerformanceRepository.SetupEnglandPerformance(
+            Build.Ks2Performance.England(x => x.WithMathsScaledScore(current: "108.4", prev: "107.6", prev2: "106.8")));
+
+        var page = await Fixture.RequestPageAsync(
+            Routes.PrimarySchool(PrimarySchoolUrn).SimilarSchoolComparisonKs2(SimilarSchoolUrn));
+
+        var table = page.ElementWithTestIdShouldExist<IHtmlTableElement>("maths-score-table-view-table");
+
+        table.ShouldHaveRows(
+            ["School(s)", "2022 to 2023", "2023 to 2024", "2024 to 2025"],
+            ["Test School 1", "100.4", "101.4", "102.4"],
+            ["Test School 2", "102.2", "103.2", "104.2"],
+            ["Schools in England average", "106.8", "107.6", "108.4"]);
+    }
+
+    [Fact]
+    public async Task MeetingExpectedStandardGps_MeasureExistsOnPage()
+    {
+        var page = await Fixture.RequestPageAsync(
+            Routes.PrimarySchool(PrimarySchoolUrn).SimilarSchoolComparisonKs2(SimilarSchoolUrn));
+
+        var heading = page.ElementWithTestIdShouldExist("expected-gps-heading");
+        heading.TrimmedTextContent().Should().Be("Meeting expected standard in grammar, punctuation and spelling");
+
+        var section = heading.Closest(".app-measure-section");
+        section.Should().NotBeNull();
+
+        var details = section!.QuerySelector("details.govuk-details");
+        details.Should().NotBeNull();
+        details!.QuerySelector(".govuk-details__summary-text")!.TrimmedTextContent()
+            .Should().Be("Information about meeting the expected standard");
+        details.HasAttribute("open").Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task MeetingExpectedStandardGps_TableView_ShouldShowCorrectValues()
+    {
+        Fixture.Ks2PerformanceRepository.SetupEstablishmentPerformance(
+            Build.Ks2Performance.Establishment(PrimarySchoolUrn, x => x.WithGpsExpected(current: "62", prev: "61", prev2: "60")),
+            Build.Ks2Performance.Establishment(SimilarSchoolUrn, x => x.WithGpsExpected(current: "77", prev: "76", prev2: "75")));
+
+        Fixture.Ks2PerformanceRepository.SetupEnglandPerformance(
+            Build.Ks2Performance.England(x => x.WithGpsExpected(current: "69", prev: "68", prev2: "67")));
+
+        var page = await Fixture.RequestPageAsync(
+            Routes.PrimarySchool(PrimarySchoolUrn).SimilarSchoolComparisonKs2(SimilarSchoolUrn));
+
+        var table = page.ElementWithTestIdShouldExist<IHtmlTableElement>("expected-gps-table-view-table");
+
+        table.ShouldHaveRows(
+            ["School(s)", "2022 to 2023", "2023 to 2024", "2024 to 2025"],
+            ["Test School 1", "60%", "61%", "62%"],
+            ["Test School 2", "75%", "76%", "77%"],
+            ["Schools in England average", "67%", "68%", "69%"]);
+    }
+
+    [Fact]
+    public async Task AchievedHigherStandardGps_MeasureExistsOnPage()
+    {
+        var page = await Fixture.RequestPageAsync(
+            Routes.PrimarySchool(PrimarySchoolUrn).SimilarSchoolComparisonKs2(SimilarSchoolUrn));
+
+        var heading = page.ElementWithTestIdShouldExist("higher-gps-heading");
+        heading.TrimmedTextContent().Should().Be("Achieved a higher standard in grammar, punctuation and spelling");
+
+        var section = heading.Closest(".app-measure-section");
+        section.Should().NotBeNull();
+
+        var details = section!.QuerySelector("details.govuk-details");
+        details.Should().NotBeNull();
+        details!.QuerySelector(".govuk-details__summary-text")!.TrimmedTextContent()
+            .Should().Be("Information about achieving the higher standard");
+        details.HasAttribute("open").Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task AchievedHigherStandardGps_TableView_ShouldShowCorrectValues()
+    {
+        Fixture.Ks2PerformanceRepository.SetupEstablishmentPerformance(
+            Build.Ks2Performance.Establishment(PrimarySchoolUrn, x => x.WithGpsHigher(current: "18", prev: "17", prev2: "16")),
+            Build.Ks2Performance.Establishment(SimilarSchoolUrn, x => x.WithGpsHigher(current: "24", prev: "23", prev2: "22")));
+
+        Fixture.Ks2PerformanceRepository.SetupEnglandPerformance(
+            Build.Ks2Performance.England(x => x.WithGpsHigher(current: "15", prev: "14", prev2: "13")));
+
+        var page = await Fixture.RequestPageAsync(
+            Routes.PrimarySchool(PrimarySchoolUrn).SimilarSchoolComparisonKs2(SimilarSchoolUrn));
+
+        var table = page.ElementWithTestIdShouldExist<IHtmlTableElement>("higher-gps-table-view-table");
+
+        table.ShouldHaveRows(
+            ["School(s)", "2022 to 2023", "2023 to 2024", "2024 to 2025"],
+            ["Test School 1", "16%", "17%", "18%"],
+            ["Test School 2", "22%", "23%", "24%"],
+            ["Schools in England average", "13%", "14%", "15%"]);
+    }
 }

--- a/terraform/application/config/review.yml
+++ b/terraform/application/config/review.yml
@@ -1,4 +1,4 @@
 ---
 ASPNETCORE_ENVIRONMENT: "Development"
 FeatureManagement__EnablePrimarySchools: "true"
-reset_review_db: "false"
+reset_review_db: "true"

--- a/terraform/application/config/review.yml
+++ b/terraform/application/config/review.yml
@@ -1,4 +1,4 @@
 ---
 ASPNETCORE_ENVIRONMENT: "Development"
 FeatureManagement__EnablePrimarySchools: "true"
-reset_review_db: "true"
+reset_review_db: "false"


### PR DESCRIPTION
## Description

Added the final three KS2 comparison measures — Average scaled score in maths, Meeting expected standard in grammar, punctuation and spelling, and Achieved a higher standard in grammar, punctuation and spelling — completing full parity with the non-comparison KS2 page's 6 measures (plus progress score) on the "Comparing to" page.

## Related Trello Ticket

Provide the link to the trello card here.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Unit tests added/updated 
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] Tested on [Environment: Dev/Staging/Local]

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have verified accessibility requirements are met


## Screenshots (if applicable)

Add UI changes, logs, console outputs anything to help reviewers.